### PR TITLE
Another fix for setting up auth client or startup and/or retrying later

### DIFF
--- a/server/lib/openid-client.js
+++ b/server/lib/openid-client.js
@@ -10,11 +10,20 @@ class OpenIdClient {
     this.clientId = clientId
     this.clientSecret = clientSecret
     this.authService = authService
-    this.authClientCreated = false
+    this.initialised = false
   }
 
   async init() {
-    await this.createAuthClient()
+    try {
+      await this.setupAuthClient()
+    } catch (err) {
+      console.error('Unable to initialise openIdClient, this will be retried later')
+      return Promise.resolve()
+    }
+  }
+
+  async setupAuthClient() {
+    await this.authService.setAuthClient()
     const issuer = await Issuer.discover(this.authUrl)
     this.client = new issuer.Client({
       client_id: this.clientId,
@@ -23,17 +32,7 @@ class OpenIdClient {
       response_types: ['code']
     })
     this.setupPassport()
-  }
-
-  async createAuthClient() {
-    try {
-      await this.authService.setAuthClient()
-      this.authClientCreated = true
-      console.log('Auth client created successfully')
-    } catch (err) {
-      console.error('Unable to create auth client, this will be retried later')
-      return Promise.resolve()
-    }
+    this.initialised = true
   }
 
   setupPassport() {

--- a/server/services/auth.js
+++ b/server/services/auth.js
@@ -29,6 +29,7 @@ class AuthService {
   async setAuthClient() {
     try {
       await axios.put(`${this.hubApi.url}/idp/clients/hub-ui`, IDPClient, this.requestOptions)
+      console.log('Auth client created successfully')
     } catch (err) {
       console.error('Error setting auth client from API', err)
       return Promise.reject(err)


### PR DESCRIPTION
* the node openID client also needs to be created later when Dex is not available