### PR TITLE
Fixing incorrect config in pre-built client-side assets

### DIFF
--- a/__tests__/pages/_app.test.js
+++ b/__tests__/pages/_app.test.js
@@ -1,6 +1,5 @@
 import axios from 'axios'
 import App from '../../pages/_app'
-import { hub } from '../../config'
 import OrgService from '../../server/services/org'
 import apiRequest from '../../lib/utils/api-request'
 import redirect from '../../lib/utils/redirect'
@@ -58,7 +57,7 @@ describe('App', () => {
 
           const userSession = await App.getUserSession()
           expect(axios.get).toHaveBeenCalledTimes(1)
-          expect(axios.get).toHaveBeenCalledWith(`${hub.baseUrl}/session/user`)
+          expect(axios.get).toHaveBeenCalledWith(`${window.location.origin}/session/user`)
           expect(userSession).toEqual(userSession)
         })
 

--- a/pages/_app.js
+++ b/pages/_app.js
@@ -37,7 +37,7 @@ class MyApp extends App {
       return false
     }
     try {
-      const result = await axios.get(`${hub.baseUrl}/session/user`)
+      const result = await axios.get(`${window.location.origin}/session/user`)
       return result.data
     } catch (err) {
       return false

--- a/pages/setup/authentication/github/index.js
+++ b/pages/setup/authentication/github/index.js
@@ -2,7 +2,7 @@ import * as React from 'react'
 import axios from 'axios'
 import PropTypes from 'prop-types'
 import { Typography, Steps, Button, Alert, Form, Input, Card } from 'antd'
-import { hub, auth } from '../../../../config'
+import { auth } from '../../../../config'
 import CopyTextWithLabel from '../../../../lib/components/CopyTextWithLabel'
 import copy from '../../../../lib/utils/object-copy'
 import redirect from '../../../../lib/utils/redirect'
@@ -85,7 +85,7 @@ class GithubSetupPage extends React.Component {
           clientSecret
         }
       }
-      await axios.post(`${hub.baseUrl}/login/auth/configure`, body)
+      await axios.post(`${window.location.origin}/login/auth/configure`, body)
       return redirect(null, '/setup/authentication/github/complete')
     } catch (err) {
       console.error('Error submitting form', err)

--- a/pages/setup/authentication/google/index.js
+++ b/pages/setup/authentication/google/index.js
@@ -164,7 +164,7 @@ class GoogleSetupPage extends React.Component {
           clientSecret
         }
       }
-      await axios.post(`${hub.baseUrl}/login/auth/configure`, body)
+      await axios.post(`${window.location.origin}/login/auth/configure`, body)
       return redirect(null, '/setup/authentication/google/complete')
     } catch (err) {
       console.error('Error submitting form', err)


### PR DESCRIPTION
* grabbing the app URL from the window object instead of config
* some other URLs shown in the instructions for configuring auth providers still need to be fixed
* it's not worth doing that until it's clearer on the direction of this feature