### PR TITLE
Prevent page content being shown when there is no user session

### DIFF
--- a/pages/_app.js
+++ b/pages/_app.js
@@ -77,6 +77,11 @@ class MyApp extends App {
     const props = { ...this.props, ...this.props.pageProps }
     const isAdmin = Boolean(props.user && props.user.isAdmin)
     const hideSider = Boolean(props.hideSider || props.unrestrictedPage)
+    const hidePage = Boolean(!props.unrestrictedPage && !props.user)
+
+    if (hidePage) {
+      return null
+    }
 
     return (
       <div>


### PR DESCRIPTION
* check for user in props and don't render the page unless there is one

Fixes #19 