### PR TITLE
Multi-cluster provider form tweaks

### DIFF
--- a/lib/components/cluster-build/ClusterOptionsForm.js
+++ b/lib/components/cluster-build/ClusterOptionsForm.js
@@ -16,7 +16,7 @@ class ClusterOptionsForm extends React.Component {
   }
 
   state = {
-    selectedProvider: false,
+    selectedProvider: this.props.providers.length === 1 ? this.props.providers[0] : false,
     selectedPlan: false
   }
 
@@ -102,6 +102,7 @@ class ClusterOptionsForm extends React.Component {
         <Form.Item label="Provider">
           {getFieldDecorator('provider', {
             rules: [{ required: true, message: 'Please select your provider!' }],
+            initialValue: selectedProvider ? selectedProvider.metadata.name : undefined
           })(
             <Select
               placeholder="Provider"

--- a/lib/components/cluster-build/KubernetesOptionsForm.js
+++ b/lib/components/cluster-build/KubernetesOptionsForm.js
@@ -17,7 +17,7 @@ class KubernetesOptionsForm extends React.Component {
           {getFieldDecorator('domain', {
             rules: [{ required: true, message: 'Please enter the domain!' }],
           })(
-            <Input id="domain" key="k8s_dom" placeholder="Domain" />
+            <Input id="domain" placeholder="Domain" />
           )}
         </Form.Item>
       </Card>
@@ -25,6 +25,6 @@ class KubernetesOptionsForm extends React.Component {
   }
 }
 
-const WrappedKubernetesOptionsForm = Form.create({ name: 'cluster_options' })(KubernetesOptionsForm)
+const WrappedKubernetesOptionsForm = Form.create({ name: 'kubernetes_options' })(KubernetesOptionsForm)
 
 export default WrappedKubernetesOptionsForm

--- a/lib/components/forms/ClusterBuildForm.js
+++ b/lib/components/forms/ClusterBuildForm.js
@@ -129,9 +129,11 @@ class ClusterBuildForm extends React.Component {
   }
 
   handleSelectCloud = cloud => {
-    const state = copy(this.state)
-    state.selectedCloud = cloud
-    this.setState(state)
+    if (this.state.selectedCloud !== cloud) {
+      const state = copy(this.state)
+      state.selectedCloud = cloud
+      this.setState(state)
+    }
   }
 
   render() {


### PR DESCRIPTION
* don’t update state with selected cloud if it’s already set (prevents form re-render)
* removing redundant key attribute on input
* fixing KubernetesOptionsForm name
* auto-select provider if only one exists