### PR TITLE
Team resource auto-refresh

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,6 +40,10 @@ Once this is complete, you can install and run the Kore UI as follows
 ```bash
 # run dependencies
 make compose
+# set environment variables
+export KORE_DISCOVERY_URL=https://<your-openid-domain>
+export KORE_CLIENT_ID=<your-openid-client-id>
+export KORE_CLIENT_SECRET=<your-openid-client-secret>
 # install and run the UI
 npm install
 npm run dev

--- a/lib/components/ResourceStatusTag.js
+++ b/lib/components/ResourceStatusTag.js
@@ -7,6 +7,8 @@ const ResourceStatusTag = ({ resourceStatus }) => {
   const status = resourceStatus.status || 'Pending'
   const components = resourceStatus.components
 
+  const statusTag = <Tag color={statusColorMap[status] || 'red'}>{status === 'Pending' ? <Icon type="loading" /> : null} {status}</Tag>
+
   if (components) {
     return (
       <Popover placement="left" content={
@@ -25,12 +27,12 @@ const ResourceStatusTag = ({ resourceStatus }) => {
           )}
         </Timeline>
       }>
-        <Tag color={statusColorMap[status] || 'red'}>{status === 'Pending' ? <Icon type="loading" /> : null} {status}</Tag>
+        {statusTag}
       </Popover>
     )
   }
 
-  return <Tag color={statusColorMap[status] || 'red'}>{status === 'Pending' ? <Icon type="loading" /> : null} {status}</Tag>
+  return statusTag
 }
 
 ResourceStatusTag.propTypes = {

--- a/lib/components/ResourceStatusTag.js
+++ b/lib/components/ResourceStatusTag.js
@@ -1,13 +1,40 @@
 import PropTypes from 'prop-types'
-import { Icon, Tag } from 'antd'
 import { statusColorMap } from '../utils/ui-helpers'
+import { Icon, Tag, Popover, Timeline, Typography } from 'antd'
+const { Text } = Typography
 
-const ResourceStatusTag = ({ status }) => (
-  <Tag color={statusColorMap[status] || 'red'}>{status === 'Pending' ? <Icon type="loading" /> : null} {status}</Tag>
-)
+const ResourceStatusTag = ({ resourceStatus }) => {
+  const status = resourceStatus.status || 'Pending'
+  const components = resourceStatus.components
+
+  if (components) {
+    return (
+      <Popover placement="left" content={
+        <Timeline
+          pending={!status || status === 'Pending'}
+          style={{
+            marginTop: '25px',
+            marginLeft: '10px',
+            marginRight: '10px',
+            marginBottom: status !== 'Pending' ? '-30px' : '0'
+          }}>
+          {components.map((c, idx) =>
+            <Timeline.Item key={idx} color={statusColorMap[c.status] || 'red'}>
+              <Text strong>{c.status}: </Text><Text>{c.message}</Text>
+            </Timeline.Item>
+          )}
+        </Timeline>
+      }>
+        <Tag color={statusColorMap[status] || 'red'}>{status === 'Pending' ? <Icon type="loading" /> : null} {status}</Tag>
+      </Popover>
+    )
+  }
+
+  return <Tag color={statusColorMap[status] || 'red'}>{status === 'Pending' ? <Icon type="loading" /> : null} {status}</Tag>
+}
 
 ResourceStatusTag.propTypes = {
-  status: PropTypes.string.isRequired
+  resourceStatus: PropTypes.object.isRequired
 }
 
 export default ResourceStatusTag

--- a/lib/components/ResourceStatusTag.js
+++ b/lib/components/ResourceStatusTag.js
@@ -1,0 +1,13 @@
+import PropTypes from 'prop-types'
+import { Icon, Tag } from 'antd'
+import { statusColorMap } from '../utils/ui-helpers'
+
+const ResourceStatusTag = ({ status }) => (
+  <Tag color={statusColorMap[status] || 'red'}>{status === 'Pending' ? <Icon type="loading" /> : null} {status}</Tag>
+)
+
+ResourceStatusTag.propTypes = {
+  status: PropTypes.string.isRequired
+}
+
+export default ResourceStatusTag

--- a/lib/components/ResourceStatusTag.js
+++ b/lib/components/ResourceStatusTag.js
@@ -1,11 +1,12 @@
 import PropTypes from 'prop-types'
 import { statusColorMap } from '../utils/ui-helpers'
 import { Icon, Tag, Popover, Timeline, Typography } from 'antd'
-const { Text } = Typography
+const { Text, Paragraph } = Typography
 
 const ResourceStatusTag = ({ resourceStatus }) => {
   const status = resourceStatus.status || 'Pending'
   const components = resourceStatus.components
+  const conditions = resourceStatus.conditions
 
   const statusTag = <Tag color={statusColorMap[status] || 'red'}>{status === 'Pending' ? <Icon type="loading" /> : null} {status}</Tag>
 
@@ -26,6 +27,22 @@ const ResourceStatusTag = ({ resourceStatus }) => {
             </Timeline.Item>
           )}
         </Timeline>
+      }>
+        {statusTag}
+      </Popover>
+    )
+  }
+
+  if (conditions && conditions.length) {
+    return (
+      <Popover placement="left" content={
+        conditions.map((c, idx) =>
+          <Paragraph key={idx} style={{ marginBottom: '0', padding: '5px' }}>
+            <Text strong>{c.message}</Text>
+            <br/>
+            <Text>{c.detail}</Text>
+          </Paragraph>
+        )
       }>
         {statusTag}
       </Popover>

--- a/lib/components/team/AutoRefreshComponent.js
+++ b/lib/components/team/AutoRefreshComponent.js
@@ -1,0 +1,50 @@
+import * as React from 'react'
+import apiRequest from '../../utils/api-request'
+import copy from '../../utils/object-copy'
+
+/*
+ Properties that must be set on the parent
+   - refreshMs - how often to refresh the state
+   - stateResourceDataKey - where is the data located in the state object
+   - resourceApiPath - API path for requesting updated resource data
+ */
+
+class AutoRefreshComponent extends React.Component {
+
+  FINAL_STATES = ['Success', 'Failure']
+
+  isFinalState() {
+    return this.FINAL_STATES.includes(this.state[this.stateResourceDataKey].status.status)
+  }
+
+  checkClearInterval() {
+    if (this.isFinalState()) {
+      this.showMessage && this.showMessage(this.state[this.stateResourceDataKey].status.status)
+      clearInterval(this.interval)
+    }
+  }
+
+  async fetchResource() {
+    const resourceData = await apiRequest(null, 'get', this.resourceApiPath)
+    return resourceData
+  }
+
+  componentDidMount() {
+    if (!this.isFinalState()) {
+      this.interval = setInterval(async () => {
+        const resourceData = await this.fetchResource()
+        const state = copy(this.state)
+        state[this.stateResourceDataKey] = resourceData
+        this.setState(state)
+        this.checkClearInterval()
+      }, this.refreshMs)
+    }
+  }
+
+  componentWillUnmount() {
+    clearInterval(this.interval)
+  }
+
+}
+
+export default AutoRefreshComponent

--- a/lib/components/team/Cluster.js
+++ b/lib/components/team/Cluster.js
@@ -107,30 +107,7 @@ class Cluster extends React.Component {
         actions.push(deleteAction)
       }
 
-      if (cluster.status.components) {
-        actions.push(
-          <Popover placement="left" content={
-            <Timeline
-              pending={!status || status === 'Pending'}
-              style={{
-                marginTop: '25px',
-                marginLeft: '10px',
-                marginRight: '10px',
-                marginBottom: status !== 'Pending' ? '-30px' : '0'
-              }}>
-              {cluster.status.components.map((c, idx) =>
-                <Timeline.Item key={idx} color={statusColorMap[c.status] || 'red'}>
-                  <Text strong>{c.status}: </Text><Text>{c.message}</Text>
-                </Timeline.Item>
-              )}
-            </Timeline>
-          }>
-            <ResourceStatusTag status={status} />
-          </Popover>
-        )
-      } else {
-        <ResourceStatusTag status={status} />
-      }
+      actions.push(<ResourceStatusTag resourceStatus={cluster.status} />)
       return actions
     }
 

--- a/lib/components/team/Cluster.js
+++ b/lib/components/team/Cluster.js
@@ -1,0 +1,155 @@
+import PropTypes from 'prop-types'
+import * as React from 'react'
+import moment from 'moment'
+import { List, Icon, Typography, Modal, Popconfirm, Popover, Timeline, Tag, message } from 'antd'
+const { Text, Paragraph } = Typography
+
+import apiRequest from '../../utils/api-request'
+import copy from '../../utils/object-copy'
+
+class Cluster extends React.Component {
+  static propTypes = {
+    team: PropTypes.string.isRequired,
+    provider: PropTypes.object.isRequired,
+    cluster: PropTypes.object.isRequired,
+    namespaceClaims: PropTypes.array.isRequired,
+    handleDelete: PropTypes.func.isRequired
+  }
+
+  state = {
+    cluster: this.props.cluster
+  }
+
+  checkClearInterval() {
+    if (this.state.cluster.status.status === 'Success') {
+      clearInterval(this.interval)
+    }
+  }
+
+  async fetchResource() {
+    const team = this.props.team
+    const clusterName = this.state.cluster.metadata.name
+    const cluster = await apiRequest(null, 'get', `/teams/${team}/clusters/${clusterName}`)
+    return cluster
+  }
+
+  deleteResource = async () => {
+    const { namespaceClaims } = this.props
+    if (namespaceClaims.length > 0) {
+      return Modal.warning({
+        title: 'Warning: cluster cannot be deleted',
+        content: (
+          <div>
+            <Paragraph strong>The cluster namespaces must be deleted first</Paragraph>
+            <List
+              size="small"
+              dataSource={namespaceClaims}
+              renderItem={ns => <List.Item>{ns.metadata.name}</List.Item>}
+            />
+          </div>
+        ),
+        onOk() {}
+      })
+    }
+
+    const { team, handleDelete } = this.props
+    const cluster = this.state.cluster
+    try {
+      await apiRequest(null, 'delete', `/teams/${team}/clusters/${cluster.metadata.name}`)
+      await apiRequest(null, 'delete', `/teams/${team}/gkes/${cluster.metadata.name}`)
+      handleDelete(cluster)
+    } catch (err) {
+      console.error('Error deleting cluster', err)
+      message.error('Error deleting cluster, please try again.')
+    }
+  }
+
+  componentDidMount() {
+    if (this.state.cluster.status.status !== 'Success') {
+      this.interval = setInterval(async () => {
+        const cluster = await this.fetchResource()
+        const state = copy(this.state)
+        state.cluster = cluster
+        this.setState(state)
+        this.checkClearInterval()
+      }, 10000)
+    }
+  }
+
+  componentWillUnmount() {
+    clearInterval(this.interval)
+  }
+
+  render() {
+    const { cluster } = this.state
+    const { provider } = this.props
+
+    const created = moment(cluster.metadata.creationTimestamp).fromNow()
+
+    const statusColorMap = { 'Success': 'green', 'Pending': 'orange' }
+    const clusterProviderIconSrcMap = {
+      'GKECredentials': '/static/images/GKE.png',
+      'EKSCredentials': '/static/images/EKS.png'
+    }
+
+    const actions = () => {
+      const actions = []
+      const status = cluster.status.status || 'Pending'
+      const statusTag = <Tag color={statusColorMap[status] || 'red'}>{status === 'Pending' ? <Icon type="loading" /> : null} {status}</Tag>
+
+      if (status === 'Success') {
+        const deleteAction = (
+          <Popconfirm
+            key="delete"
+            title="Are you sure you want to delete this cluster?"
+            onConfirm={this.deleteResource}
+            okText="Yes"
+            cancelText="No"
+          >
+            <a><Icon type="delete" /></a>
+          </Popconfirm>
+        )
+        actions.push(deleteAction)
+      }
+
+      if (cluster.status.components) {
+        actions.push(
+          <Popover placement="left" content={
+            <Timeline
+              pending={!status || status === 'Pending'}
+              style={{
+                marginTop: '25px',
+                marginLeft: '10px',
+                marginRight: '10px',
+                marginBottom: status !== 'Pending' ? '-30px' : '0'
+              }}>
+              {cluster.status.components.map((c, idx) =>
+                <Timeline.Item key={idx} color={statusColorMap[c.status] || 'red'}>
+                  <Text strong>{c.status}: </Text><Text>{c.message}</Text>
+                </Timeline.Item>
+              )}
+            </Timeline>
+          }>
+            {statusTag}
+          </Popover>
+        )
+      } else {
+        actions.push(statusTag)
+      }
+      return actions
+    }
+
+    return (
+      <List.Item actions={actions()}>
+        <List.Item.Meta
+          avatar={<img src={clusterProviderIconSrcMap[provider.spec.resource.kind]} height="32px" />}
+          title={<Text>{provider.spec.name} <Text style={{ fontFamily: 'monospace', marginLeft: '15px' }}>{cluster.metadata.name}</Text></Text>}
+          description={<Text type='secondary'>Created {created}</Text>}
+        />
+      </List.Item>
+    )
+  }
+
+}
+
+export default Cluster

--- a/lib/components/team/Cluster.js
+++ b/lib/components/team/Cluster.js
@@ -1,15 +1,14 @@
 import PropTypes from 'prop-types'
-import * as React from 'react'
 import moment from 'moment'
-import { List, Icon, Typography, Modal, Popconfirm, Popover, Timeline, message } from 'antd'
+import { List, Icon, Typography, Modal, Popconfirm, message } from 'antd'
 const { Text, Paragraph } = Typography
 
 import apiRequest from '../../utils/api-request'
-import { statusColorMap, clusterProviderIconSrcMap } from '../../utils/ui-helpers'
-import copy from '../../utils/object-copy'
+import { clusterProviderIconSrcMap } from '../../utils/ui-helpers'
 import ResourceStatusTag from '../ResourceStatusTag'
+import AutoRefreshComponent from './AutoRefreshComponent'
 
-class Cluster extends React.Component {
+class Cluster extends AutoRefreshComponent {
   static propTypes = {
     team: PropTypes.string.isRequired,
     provider: PropTypes.object.isRequired,
@@ -18,21 +17,24 @@ class Cluster extends React.Component {
     handleDelete: PropTypes.func.isRequired
   }
 
-  state = {
-    cluster: this.props.cluster
-  }
-
-  checkClearInterval() {
-    if (this.state.cluster.status.status === 'Success') {
-      clearInterval(this.interval)
+  constructor(props) {
+    super(props)
+    this.state = {
+      cluster: this.props.cluster
     }
+    this.refreshMs = 10000
+    this.stateResourceDataKey = 'cluster'
+    this.resourceApiPath = `/teams/${props.team}/clusters/${props.cluster.metadata.name}`
   }
 
-  async fetchResource() {
-    const team = this.props.team
-    const clusterName = this.state.cluster.metadata.name
-    const cluster = await apiRequest(null, 'get', `/teams/${team}/clusters/${clusterName}`)
-    return cluster
+  showMessage(status) {
+    const cluster = this.state.cluster
+    if (status === 'Success') {
+      message.success(`Cluster successfully created: ${cluster.metadata.name}`)
+    }
+    if (status === 'Failure') {
+      message.error(`Cluster failed to create: ${cluster.metadata.name}`)
+    }
   }
 
   deleteResource = async () => {
@@ -64,22 +66,6 @@ class Cluster extends React.Component {
       console.error('Error deleting cluster', err)
       message.error('Error deleting cluster, please try again.')
     }
-  }
-
-  componentDidMount() {
-    if (this.state.cluster.status.status !== 'Success') {
-      this.interval = setInterval(async () => {
-        const cluster = await this.fetchResource()
-        const state = copy(this.state)
-        state.cluster = cluster
-        this.setState(state)
-        this.checkClearInterval()
-      }, 10000)
-    }
-  }
-
-  componentWillUnmount() {
-    clearInterval(this.interval)
   }
 
   render() {

--- a/lib/components/team/Cluster.js
+++ b/lib/components/team/Cluster.js
@@ -4,6 +4,7 @@ import { List, Icon, Typography, Modal, Popconfirm, message } from 'antd'
 const { Text, Paragraph } = Typography
 
 import apiRequest from '../../utils/api-request'
+import copy from '../../utils/object-copy'
 import { clusterProviderIconSrcMap } from '../../utils/ui-helpers'
 import ResourceStatusTag from '../ResourceStatusTag'
 import AutoRefreshComponent from './AutoRefreshComponent'
@@ -13,8 +14,7 @@ class Cluster extends AutoRefreshComponent {
     team: PropTypes.string.isRequired,
     provider: PropTypes.object.isRequired,
     cluster: PropTypes.object.isRequired,
-    namespaceClaims: PropTypes.array.isRequired,
-    handleDelete: PropTypes.func.isRequired
+    namespaceClaims: PropTypes.array.isRequired
   }
 
   constructor(props) {
@@ -56,12 +56,15 @@ class Cluster extends AutoRefreshComponent {
       })
     }
 
-    const { team, handleDelete } = this.props
-    const cluster = this.state.cluster
+    const { team } = this.props
     try {
+      const state = copy(this.state)
+      const cluster = state.cluster
       await apiRequest(null, 'delete', `/teams/${team}/clusters/${cluster.metadata.name}`)
       await apiRequest(null, 'delete', `/teams/${team}/gkes/${cluster.metadata.name}`)
-      handleDelete(cluster)
+      state.cluster.deleted = true
+      this.setState(state)
+      message.loading(`Cluster deletion requested: ${cluster.metadata.name}`)
     } catch (err) {
       console.error('Error deleting cluster', err)
       message.error('Error deleting cluster, please try again.')
@@ -71,6 +74,10 @@ class Cluster extends AutoRefreshComponent {
   render() {
     const { cluster } = this.state
     const { provider } = this.props
+
+    if (cluster.deleted) {
+      return null
+    }
 
     const created = moment(cluster.metadata.creationTimestamp).fromNow()
 

--- a/lib/components/team/Cluster.js
+++ b/lib/components/team/Cluster.js
@@ -1,11 +1,13 @@
 import PropTypes from 'prop-types'
 import * as React from 'react'
 import moment from 'moment'
-import { List, Icon, Typography, Modal, Popconfirm, Popover, Timeline, Tag, message } from 'antd'
+import { List, Icon, Typography, Modal, Popconfirm, Popover, Timeline, message } from 'antd'
 const { Text, Paragraph } = Typography
 
 import apiRequest from '../../utils/api-request'
+import { statusColorMap, clusterProviderIconSrcMap } from '../../utils/ui-helpers'
 import copy from '../../utils/object-copy'
+import ResourceStatusTag from '../ResourceStatusTag'
 
 class Cluster extends React.Component {
   static propTypes = {
@@ -86,16 +88,9 @@ class Cluster extends React.Component {
 
     const created = moment(cluster.metadata.creationTimestamp).fromNow()
 
-    const statusColorMap = { 'Success': 'green', 'Pending': 'orange' }
-    const clusterProviderIconSrcMap = {
-      'GKECredentials': '/static/images/GKE.png',
-      'EKSCredentials': '/static/images/EKS.png'
-    }
-
     const actions = () => {
       const actions = []
       const status = cluster.status.status || 'Pending'
-      const statusTag = <Tag color={statusColorMap[status] || 'red'}>{status === 'Pending' ? <Icon type="loading" /> : null} {status}</Tag>
 
       if (status === 'Success') {
         const deleteAction = (
@@ -130,11 +125,11 @@ class Cluster extends React.Component {
               )}
             </Timeline>
           }>
-            {statusTag}
+            <ResourceStatusTag status={status} />
           </Popover>
         )
       } else {
-        actions.push(statusTag)
+        <ResourceStatusTag status={status} />
       }
       return actions
     }

--- a/lib/components/team/NamespaceClaim.js
+++ b/lib/components/team/NamespaceClaim.js
@@ -1,0 +1,104 @@
+import PropTypes from 'prop-types'
+import * as React from 'react'
+import moment from 'moment'
+import { List, Avatar, Icon, Typography, Popconfirm, Tag, message } from 'antd'
+const { Text } = Typography
+
+import apiRequest from '../../utils/api-request'
+import copy from '../../utils/object-copy'
+
+class NamespaceClaim extends React.Component {
+  static propTypes = {
+    team: PropTypes.string.isRequired,
+    namespaceClaim: PropTypes.object.isRequired,
+    handleDelete: PropTypes.func.isRequired
+  }
+
+  state = {
+    namespaceClaim: this.props.namespaceClaim
+  }
+
+  checkClearInterval() {
+    if (this.state.namespaceClaim.status.status === 'Success') {
+      clearInterval(this.interval)
+    }
+  }
+
+  async fetchResource() {
+    const team = this.props.team
+    const ncName = this.state.namespaceClaim.metadata.name
+    const namespaceClaim = await apiRequest(null, 'get', `/teams/${team}/namespaceclaims/${ncName}`)
+    return namespaceClaim
+  }
+
+  deleteResource = async () => {
+    const { team, handleDelete } = this.props
+    const namespaceClaim = this.state.namespaceClaim
+    try {
+      await apiRequest(null, 'delete', `/teams/${team}/namespaceclaims/${namespaceClaim.metadata.name}`)
+      handleDelete(namespaceClaim)
+    } catch (err) {
+      console.error('Error deleting namespace', err)
+      message.error('Error deleting namespace, please try again.')
+    }
+  }
+
+  componentDidMount() {
+    if (this.state.namespaceClaim.status.status !== 'Success') {
+      this.interval = setInterval(async () => {
+        const namespaceClaim = await this.fetchResource()
+        const state = copy(this.state)
+        state.namespaceClaim = namespaceClaim
+        this.setState(state)
+        this.checkClearInterval()
+      }, 2000)
+    }
+  }
+
+  componentWillUnmount() {
+    clearInterval(this.interval)
+  }
+
+  render() {
+    const { namespaceClaim } = this.state
+
+    const clusterName = namespaceClaim.spec.cluster.name
+    const created = moment(namespaceClaim.metadata.creationTimestamp).fromNow()
+
+    const statusColorMap = { 'Success': 'green', 'Pending': 'orange' }
+
+    const actions = () => {
+      const actions = []
+      const status = namespaceClaim.status.status || 'Pending'
+      if (status === 'Success') {
+        const deleteAction = (
+          <Popconfirm
+            key="delete"
+            title="Are you sure you want to delete this namespace?"
+            onConfirm={this.deleteResource}
+            okText="Yes"
+            cancelText="No"
+          >
+            <a><Icon type="delete" /></a>
+          </Popconfirm>
+        )
+        actions.push(deleteAction)
+      }
+      actions.push(<Tag color={statusColorMap[status] || 'red'}>{status === 'Pending' ? <Icon type="loading" /> : null} {status}</Tag>)
+      return actions
+    }
+
+    return (
+      <List.Item actions={actions()}>
+        <List.Item.Meta
+          avatar={<Avatar icon="block" />}
+          title={<Text>{namespaceClaim.metadata.name} <Text style={{ fontFamily: 'monospace', marginLeft: '15px' }}>{clusterName}</Text></Text>}
+          description={<div><Text type='secondary'>Created {created}</Text></div>}
+        />
+      </List.Item>
+    )
+  }
+
+}
+
+export default NamespaceClaim

--- a/lib/components/team/NamespaceClaim.js
+++ b/lib/components/team/NamespaceClaim.js
@@ -1,35 +1,37 @@
 import PropTypes from 'prop-types'
-import * as React from 'react'
 import moment from 'moment'
 import { List, Avatar, Icon, Typography, Popconfirm, message } from 'antd'
 const { Text } = Typography
 
 import apiRequest from '../../utils/api-request'
-import copy from '../../utils/object-copy'
 import ResourceStatusTag from '../ResourceStatusTag'
+import AutoRefreshComponent from './AutoRefreshComponent'
 
-class NamespaceClaim extends React.Component {
+class NamespaceClaim extends AutoRefreshComponent {
   static propTypes = {
     team: PropTypes.string.isRequired,
     namespaceClaim: PropTypes.object.isRequired,
     handleDelete: PropTypes.func.isRequired
   }
 
-  state = {
-    namespaceClaim: this.props.namespaceClaim
-  }
-
-  checkClearInterval() {
-    if (this.state.namespaceClaim.status.status === 'Success') {
-      clearInterval(this.interval)
+  constructor(props) {
+    super(props)
+    this.state = {
+      namespaceClaim: props.namespaceClaim
     }
+    this.refreshMs = 2000
+    this.stateResourceDataKey = 'namespaceClaim'
+    this.resourceApiPath = `/teams/${props.team}/namespaceclaims/${props.namespaceClaim.metadata.name}`
   }
 
-  async fetchResource() {
-    const team = this.props.team
-    const ncName = this.state.namespaceClaim.metadata.name
-    const namespaceClaim = await apiRequest(null, 'get', `/teams/${team}/namespaceclaims/${ncName}`)
-    return namespaceClaim
+  showMessage(status) {
+    const namespaceClaim = this.state.namespaceClaim
+    if (status === 'Success') {
+      message.success(`Namespace "${namespaceClaim.spec.name}" created on cluster "${namespaceClaim.spec.cluster.name}"`)
+    }
+    if (status === 'Failure') {
+      message.error(`Namespace "${namespaceClaim.spec.name}" failed to create on cluster "${namespaceClaim.spec.cluster.name}"`)
+    }
   }
 
   deleteResource = async () => {
@@ -42,22 +44,6 @@ class NamespaceClaim extends React.Component {
       console.error('Error deleting namespace', err)
       message.error('Error deleting namespace, please try again.')
     }
-  }
-
-  componentDidMount() {
-    if (this.state.namespaceClaim.status.status !== 'Success') {
-      this.interval = setInterval(async () => {
-        const namespaceClaim = await this.fetchResource()
-        const state = copy(this.state)
-        state.namespaceClaim = namespaceClaim
-        this.setState(state)
-        this.checkClearInterval()
-      }, 2000)
-    }
-  }
-
-  componentWillUnmount() {
-    clearInterval(this.interval)
   }
 
   render() {

--- a/lib/components/team/NamespaceClaim.js
+++ b/lib/components/team/NamespaceClaim.js
@@ -4,6 +4,7 @@ import { List, Avatar, Icon, Typography, Popconfirm, message } from 'antd'
 const { Text } = Typography
 
 import apiRequest from '../../utils/api-request'
+import copy from '../../utils/object-copy'
 import ResourceStatusTag from '../ResourceStatusTag'
 import AutoRefreshComponent from './AutoRefreshComponent'
 
@@ -11,7 +12,7 @@ class NamespaceClaim extends AutoRefreshComponent {
   static propTypes = {
     team: PropTypes.string.isRequired,
     namespaceClaim: PropTypes.object.isRequired,
-    handleDelete: PropTypes.func.isRequired
+    handleDelete: PropTypes.func
   }
 
   constructor(props) {
@@ -36,10 +37,14 @@ class NamespaceClaim extends AutoRefreshComponent {
 
   deleteResource = async () => {
     const { team, handleDelete } = this.props
-    const namespaceClaim = this.state.namespaceClaim
     try {
-      await apiRequest(null, 'delete', `/teams/${team}/namespaceclaims/${namespaceClaim.metadata.name}`)
-      handleDelete(namespaceClaim)
+      const state = copy(this.state)
+      const namespaceClaim = state.namespaceClaim
+      await apiRequest(null, 'delete', `/teams/${team}/namespaceclaims/${state.namespaceClaim.metadata.name}`)
+      state.namespaceClaim.deleted = true
+      this.setState(state)
+      handleDelete && handleDelete(namespaceClaim)
+      message.success(`Namespace deleted: ${state.namespaceClaim.spec.name}`)
     } catch (err) {
       console.error('Error deleting namespace', err)
       message.error('Error deleting namespace, please try again.')
@@ -48,6 +53,10 @@ class NamespaceClaim extends AutoRefreshComponent {
 
   render() {
     const { namespaceClaim } = this.state
+
+    if (namespaceClaim.deleted) {
+      return null
+    }
 
     const clusterName = namespaceClaim.spec.cluster.name
     const created = moment(namespaceClaim.metadata.creationTimestamp).fromNow()

--- a/lib/components/team/NamespaceClaim.js
+++ b/lib/components/team/NamespaceClaim.js
@@ -1,11 +1,12 @@
 import PropTypes from 'prop-types'
 import * as React from 'react'
 import moment from 'moment'
-import { List, Avatar, Icon, Typography, Popconfirm, Tag, message } from 'antd'
+import { List, Avatar, Icon, Typography, Popconfirm, message } from 'antd'
 const { Text } = Typography
 
 import apiRequest from '../../utils/api-request'
 import copy from '../../utils/object-copy'
+import ResourceStatusTag from '../ResourceStatusTag'
 
 class NamespaceClaim extends React.Component {
   static propTypes = {
@@ -65,8 +66,6 @@ class NamespaceClaim extends React.Component {
     const clusterName = namespaceClaim.spec.cluster.name
     const created = moment(namespaceClaim.metadata.creationTimestamp).fromNow()
 
-    const statusColorMap = { 'Success': 'green', 'Pending': 'orange' }
-
     const actions = () => {
       const actions = []
       const status = namespaceClaim.status.status || 'Pending'
@@ -84,7 +83,7 @@ class NamespaceClaim extends React.Component {
         )
         actions.push(deleteAction)
       }
-      actions.push(<Tag color={statusColorMap[status] || 'red'}>{status === 'Pending' ? <Icon type="loading" /> : null} {status}</Tag>)
+      actions.push(<ResourceStatusTag status={status} />)
       return actions
     }
 

--- a/lib/components/team/NamespaceClaim.js
+++ b/lib/components/team/NamespaceClaim.js
@@ -83,7 +83,7 @@ class NamespaceClaim extends React.Component {
         )
         actions.push(deleteAction)
       }
-      actions.push(<ResourceStatusTag status={status} />)
+      actions.push(<ResourceStatusTag resourceStatus={namespaceClaim.status} />)
       return actions
     }
 

--- a/lib/utils/ui-helpers.js
+++ b/lib/utils/ui-helpers.js
@@ -1,0 +1,10 @@
+module.exports = {
+  statusColorMap: {
+    'Success': 'green',
+    'Pending': 'orange'
+  },
+  clusterProviderIconSrcMap: {
+    'GKECredentials': '/static/images/GKE.png',
+    'EKSCredentials': '/static/images/EKS.png'
+  }
+}

--- a/pages/teams/[name].js
+++ b/pages/teams/[name].js
@@ -131,13 +131,6 @@ class TeamDashboard extends React.Component {
     }
   }
 
-  handleClusterDeleted = cluster => {
-    const state = copy(this.state)
-    state.clusters.items = state.clusters.items.filter(c => c.metadata.name !== cluster.metadata.name)
-    this.setState(state)
-    message.loading(`Cluster deletion requested: ${cluster.metadata.name}`)
-  }
-
   createNamespace = value => {
     return () => {
       const state = copy(this.state)
@@ -156,9 +149,9 @@ class TeamDashboard extends React.Component {
 
   handleNamespaceDeleted = namespaceClaim => {
     const state = copy(this.state)
-    state.namespaceClaims.items = state.namespaceClaims.items.filter(nc => nc.metadata.name !== namespaceClaim.metadata.name)
+    const deletedNc = state.namespaceClaims.items.find(nc => nc.metadata.name === namespaceClaim.metadata.name)
+    deletedNc.deleted = true
     this.setState(state)
-    message.success(`Namespace deleted: ${namespaceClaim.spec.name}`)
   }
 
   render() {
@@ -244,7 +237,7 @@ class TeamDashboard extends React.Component {
             dataSource={clusters.items}
             renderItem={cluster => {
               const provider = available.items.find(a => a.metadata.name === cluster.spec.provider.name)
-              const namespaceClaims = (this.state.namespaceClaims.items || []).filter(nc => nc.spec.cluster.name === cluster.metadata.name)
+              const namespaceClaims = (this.state.namespaceClaims.items || []).filter(nc => nc.spec.cluster.name === cluster.metadata.name && !nc.deleted)
               return (
                 <Cluster team={this.props.team.metadata.name} cluster={cluster} provider={provider} namespaceClaims={namespaceClaims} handleDelete={this.handleClusterDeleted} />
               )
@@ -259,7 +252,7 @@ class TeamDashboard extends React.Component {
           extra={clusters.items.length > 0 ? <Button type="primary" onClick={this.createNamespace(true)}>+ New</Button> : null}
         >
           <List
-            dataSource={namespaceClaims.items}
+            dataSource={namespaceClaims.items.filter(nc => !nc.deleted)}
             renderItem={namespaceClaim =>
               <NamespaceClaim team={this.props.team.metadata.name} namespaceClaim={namespaceClaim} handleDelete={this.handleNamespaceDeleted} />
             }

--- a/pages/teams/[name].js
+++ b/pages/teams/[name].js
@@ -151,7 +151,7 @@ class TeamDashboard extends React.Component {
     state.createNamespace = false
     state.namespaceClaims.items.push(namespaceClaim)
     this.setState(state)
-    message.success(`Namespace "${namespaceClaim.spec.name}" created on cluster "${namespaceClaim.spec.cluster.name}"`)
+    message.loading(`Namespace "${namespaceClaim.spec.name}" requested on cluster "${namespaceClaim.spec.cluster.name}"`)
   }
 
   handleNamespaceDeleted = namespaceClaim => {

--- a/pages/teams/[name].js
+++ b/pages/teams/[name].js
@@ -156,6 +156,8 @@ class TeamDashboard extends React.Component {
 
   render() {
     const { members, namespaceClaims, allUsers, membersToAdd, createNamespace, clusters } = this.state
+    namespaceClaims.items = namespaceClaims.items.filter(nc => !nc.deleted)
+    clusters.items = clusters.items.filter(c => !c.deleted)
     const { team, user, available } = this.props
     const teamMembers = ['ADD_USER', ...members.items]
 


### PR DESCRIPTION
**Auto-refresh of namespace claims on team page**
* refactoring a namespace claim list item into it's own component
* this allows it to be controlled individually
* refresh the namespace claim every 2 seconds until it's status is `Success`

**Auto-refresh of clusters on team page**
* refactoring a cluster list item into it's own component
* this allows it to be controlled individually
* refresh the cluster every 10 seconds until it's status is `Success`

**Moving common UI parts to components or helpers**
* component created for `ResourceStatusTag`, showing the status of a resource such as `Pending` or `Success` based on the CRD status from the API
* other useful bits of code moved to `utils/ui-helpers`

**GIF showing the auto-refresh in action** 🎉

![namespace-create-refresh](https://user-images.githubusercontent.com/1334068/74548665-3264e700-4f46-11ea-9b94-5efc86bb91ad.gif)
