### PR TITLE
Using openid claims inline with the API

### DIFF
--- a/config.js
+++ b/config.js
@@ -13,7 +13,8 @@ module.exports = {
       url: process.env.KORE_DISCOVERY_URL || 'https://my-openid-domain.com',
       callbackURL: process.env.KORE_CALLBACK_URL || 'http://localhost:3000/auth/callback',
       clientID: process.env.KORE_CLIENT_ID || 'my-openid-client-id',
-      clientSecret: process.env.KORE_CLIENT_SECRET || 'my-openid-client-secret'
+      clientSecret: process.env.KORE_CLIENT_SECRET || 'my-openid-client-secret',
+      userClaimsOrder: process.env.KORE_USER_CLAIMS || 'preferred_username,email,name,username'
     }
   },
   kore: {

--- a/lib/crd/User.js
+++ b/lib/crd/User.js
@@ -5,25 +5,25 @@ const template = (user) => ({
   apiVersion: 'org.kore.appvia.io/v1',
   kind: 'User',
   metadata: {
-    name: user.username,
+    name: user.id,
     namespace: 'kore'
   },
   spec: {
-    username: user.username,
+    username: user.id,
     email: user.email
   }
 })
 
 module.exports = async (user) => {
-  console.info(`*** Checking for user ${user.username}`)
+  console.info(`*** Checking for user ${user.id}`)
   try {
     const requestOptions = {
       headers: {
-        'X-Identity': user.username,
+        'X-Identity': user.id,
         'Authorization': `Bearer ${koreApi.token}`
       }
     }
-    const userResult = await axios.get(`${koreApi.url}/users/${user.username}`, requestOptions)
+    const userResult = await axios.get(`${koreApi.url}/users/${user.id}`, requestOptions)
     console.info('*** user found', userResult.data)
     return userResult.data
   } catch (err) {
@@ -32,7 +32,7 @@ module.exports = async (user) => {
       console.info('*** user not found, creating new resource', userResource)
       return userResource
     }
-    console.error(`*** unknown error finding user ${user.username}`, err)
+    console.error(`*** unknown error finding user ${user.id}`, err)
     return Promise.reject(err)
   }
 }

--- a/server/middleware/auth-callback.js
+++ b/server/middleware/auth-callback.js
@@ -1,9 +1,10 @@
-module.exports = (orgService, authService, koreConfig, embeddedAuth) => {
+module.exports = (orgService, authService, koreConfig, userClaimsOrder, embeddedAuth) => {
   return async (req, res) => {
     const user = req.session.passport.user
-    if (!user.username) {
-      user.username = user.preferred_username || user.email.substr(0, user.email.indexOf('@'))
-    }
+    userClaimsOrder.some(c => {
+      user.id = user[c]
+      return user.id
+    })
     const userInfo = await orgService.getOrCreateUser(user)
     /* eslint-disable require-atomic-updates */
     user.teams = userInfo.teams || []

--- a/server/routes.js
+++ b/server/routes.js
@@ -9,10 +9,11 @@ const ensureAuthenticated = require('./middleware/ensure-authenticated')
 const koreConfig = config.kore
 const koreApi = config.koreApi
 const embeddedAuth = config.auth.embedded
+const userClaimsOrder = config.auth.openid.userClaimsOrder.split(',')
 
 const authService = new AuthService(config.koreApi, config.kore.baseUrl)
 const orgService = new OrgService(config.koreApi)
-const authCallback = require('./middleware/auth-callback')(orgService, authService, koreConfig, embeddedAuth)
+const authCallback = require('./middleware/auth-callback')(orgService, authService, koreConfig, userClaimsOrder, embeddedAuth)
 
 const openIdClient = new OpenIdClient(config.kore.baseUrl, config.auth.openid, embeddedAuth, authService)
 openIdClient.init()

--- a/server/services/org.js
+++ b/server/services/org.js
@@ -17,14 +17,14 @@ class OrgService {
   async getOrCreateUser(user) {
     try {
       const userResource = await User(user)
-      console.log(`*** putting user ${user.username}`, userResource)
-      const userResult = await axios.put(`${this.koreApi.url}/users/${user.username}`, userResource, { headers: this.getHeaders(user.username) })
-      const adminTeamMembers = await this.getTeamMembers(kore.koreAdminTeamName, user.username)
+      console.log(`*** putting user ${user.id}`, userResource)
+      const userResult = await axios.put(`${this.koreApi.url}/users/${user.id}`, userResource, { headers: this.getHeaders(user.id) })
+      const adminTeamMembers = await this.getTeamMembers(kore.koreAdminTeamName, user.id)
       if (adminTeamMembers.length === 1) {
-        await this.addUserToTeam(kore.koreAdminTeamName, user.username, user.username)
+        await this.addUserToTeam(kore.koreAdminTeamName, user.id, user.id)
       }
       const userToReturn = userResult.data
-      userToReturn.teams = await this.getUserTeams(user.username, user.username)
+      userToReturn.teams = await this.getUserTeams(user.id, user.id)
       userToReturn.isAdmin = this.isAdmin(userToReturn)
       return userToReturn
     } catch (err) {
@@ -35,7 +35,7 @@ class OrgService {
 
   /* eslint-disable require-atomic-updates */
   async refreshUser(user) {
-    user.teams = await this.getUserTeams(user.username, user.username)
+    user.teams = await this.getUserTeams(user.id, user.id)
     user.isAdmin = this.isAdmin(user)
   }
   /* eslint-enable require-atomic-updates */


### PR DESCRIPTION
* this ensures that users that have logged in via the CLI and UI are matched
* adding env var backed config for ordered preference of claims
* setting the resulting value as `id` on the user object, so not as to interfere with other properties