### PR TITLE
Some simple session management

### DIFF
--- a/lib/utils/api-request.js
+++ b/lib/utils/api-request.js
@@ -1,4 +1,5 @@
 import axios from 'axios'
+import redirect from './redirect'
 import { koreApi } from '../../config'
 
 const headers = {
@@ -16,9 +17,13 @@ module.exports = async (req, method, apiPath, body, options) => {
     const result = await axios[method](
       url,
       ['get', 'delete'].includes(method) ? options : body,
-      ['get', 'delete'].includes(method) ? undefined : options)
+      ['get', 'delete'].includes(method) ? undefined : options
+    )
     return result.data
   } catch (err) {
+    if (err.response && err.response.status === 401) {
+      return redirect(null, '/login', true)
+    }
     console.error(`Error making api request, method: "${method}", url: "${url}"`, err.message)
     return method === 'get' ? {} : Promise.reject(err)
   }


### PR DESCRIPTION
Part 1:
* if receiving 401 response when trying to make an API request from the client, redirect the user to the login page

Part 2:
* setting an interval on `_app.js` to check the existence of a session and redirect to the login page if it's expired
* the interval runs after session TTL + 5 seconds (currently 20 minutes and 5 seconds)
* each interaction with the UI will clear and reset the interval (as well as the session) to reflect the amount of time left in the session
* the reason for the extra 5 seconds is because if we set the interval to the session TTL, running the session check would extend the session and it would never expire

Also:
* also removing some unused bits from `_app.js`

Closes: #46 