### PR TITLE
Adding some content to the home page

### DIFF
--- a/__tests__/pages/_app.test.js
+++ b/__tests__/pages/_app.test.js
@@ -135,7 +135,9 @@ describe('App', () => {
             staticProps: { myProp: 'myValue' },
             getInitialProps: jest.fn().mockResolvedValue(initialProps)
           },
-          ctx: {}
+          ctx: {
+            user
+          }
         }
         const props = await App.getInitialProps(params)
         expect(params.Component.getInitialProps).toHaveBeenCalledTimes(1)

--- a/lib/utils/api-request.js
+++ b/lib/utils/api-request.js
@@ -3,7 +3,7 @@ import redirect from './redirect'
 import { koreApi } from '../../config'
 import checkUserExpired from '../../server/lib/user-expired'
 
-module.exports = async (reqRes, method, apiPath, body, options) => {
+export default async (reqRes, method, apiPath, body, options) => {
   const req = reqRes && reqRes.req
   const res = reqRes && reqRes.res
   options = options || {}

--- a/pages/_app.js
+++ b/pages/_app.js
@@ -2,6 +2,7 @@ import React from 'react'
 import App from 'next/app'
 import Head from 'next/head'
 import Router from 'next/router'
+import Link from 'next/link'
 import axios from 'axios'
 import { Layout } from 'antd'
 const { Header, Content } = Layout
@@ -62,7 +63,7 @@ class MyApp extends App {
       return redirect(ctx.res, '/')
     }
     if (Component.getInitialProps) {
-      const initialProps = await Component.getInitialProps(ctx)
+      const initialProps = await Component.getInitialProps({ ...ctx, user })
       pageProps = { ...pageProps, ...initialProps }
     }
     return { pageProps, user, userTeams }
@@ -138,7 +139,11 @@ class MyApp extends App {
         </Head>
         <Layout style={{minHeight:'100vh'}}>
           <Header style={{backgroundColor: '#002140'}}>
-            <div style={{color: '#FFF', float: 'left', fontSize: '18px', marginLeft: '-25px'}}>Kore</div>
+            <div style={{color: '#FFF', float: 'left', fontSize: '18px', marginLeft: '-25px'}}>
+              <Link href="/">
+                <a style={{ color: '#FFF' }}>Kore</a>
+              </Link>
+            </div>
             <User user={props.user}/>
           </Header>
           <Layout hasSider="true" style={{minHeight:'100vh'}}>

--- a/pages/index.js
+++ b/pages/index.js
@@ -1,12 +1,182 @@
-const IndexPage = () => {
-  return (
-    <div>
-    </div>
-  )
-}
+import React from 'react'
+import PropTypes from 'prop-types'
+import Link from 'next/link'
+import { Typography, Statistic, Icon, Row, Col, Card, Alert, Button } from 'antd'
+const { Title, Paragraph } = Typography
 
-IndexPage.staticProps = {
-  title: 'Dashboard'
+import apiRequest from '../lib/utils/api-request'
+import { kore } from '../config'
+
+class IndexPage extends React.Component {
+  static propTypes = {
+    user: PropTypes.object.isRequired,
+    allUsers: PropTypes.object.isRequired,
+    allTeams: PropTypes.object.isRequired,
+    adminMembers: PropTypes.object,
+    gkeCredentials: PropTypes.object
+  }
+
+  static staticProps = {
+    title: 'Appvia Kore Dashboard'
+  }
+
+  static async getPageData(ctx) {
+    const { user } = ctx
+    let allTeams
+    let allUsers
+    let adminMembers
+    let gkeCredentials
+
+    if (user.isAdmin) {
+      [ allTeams, allUsers, adminMembers, gkeCredentials ] = await Promise.all([
+        apiRequest(ctx, 'get', '/teams'),
+        apiRequest(ctx, 'get', '/users'),
+        apiRequest(ctx, 'get', `/teams/${kore.koreAdminTeamName}/members`),
+        apiRequest(ctx, 'get', `/teams/${kore.koreAdminTeamName}/gkecredentials`)
+      ])
+    } else {
+      [ allTeams, allUsers ] = await Promise.all([
+        apiRequest(ctx, 'get', '/teams'),
+        apiRequest(ctx, 'get', '/users')
+      ])
+    }
+
+    allTeams.items = (allTeams.items || []).filter(t => !kore.ignoreTeams.includes(t.metadata.name))
+    return { allTeams, allUsers, adminMembers, gkeCredentials }
+  }
+
+  static getInitialProps = async (ctx) => {
+    const data = await IndexPage.getPageData(ctx)
+    return data
+  }
+
+  render() {
+    const { user, allTeams, allUsers, adminMembers, gkeCredentials } = this.props
+    const userTeams = (user.teams || []).filter(t => !kore.ignoreTeams.includes(t.metadata.name))
+    const noUserTeamsExist = userTeams.length === 0
+    const integrationMissing = gkeCredentials && gkeCredentials.items.length === 0
+
+    const NoTeamInfoAlert = () => noUserTeamsExist ? (
+      <Alert
+        message="You are not part of a team"
+        description={
+          <div>
+            <Paragraph style={{ marginTop: '10px' }}>Teams are everything in Kore, we recommend creating a team now to get started.</Paragraph>
+            <Button type="secondary">
+              <Link href="/teams/new">
+                <a>Create a new team</a>
+              </Link>
+            </Button>
+          </div>
+        }
+        type="info"
+        showIcon
+        style={{ marginTop: '30px' }}
+      />
+    ) : null
+
+    const IntegrationWarning = () => integrationMissing ? (
+      <Alert
+        message="No integrations configured"
+        description={
+          <div>
+            <Paragraph style={{ marginTop: '10px' }}>Without integrations Kore will be unable to create clusters for teams.</Paragraph>
+            <Button type="secondary">
+              <Link href="/configure/integrations">
+                <a>Go to integration settings</a>
+              </Link>
+            </Button>
+          </div>
+        }
+        type="warning"
+        showIcon
+        style={{ marginTop: '30px' }}
+      />
+    ) : null
+
+    const TeamStats = () => (
+      <Card title="Teams" extra={<Icon type="team" />}>
+        <Row gutter={16}>
+          <Col span={12}>
+            <Statistic style={{ textAlign: 'center' }} title="Yours" value={userTeams.length} valueStyle={{ color: noUserTeamsExist ? 'orange' : '' }} />
+          </Col>
+          <Col span={12}>
+            <Statistic style={{ textAlign: 'center' }} title="Total" value={allTeams.items.length} />
+          </Col>
+        </Row>
+      </Card>
+    )
+
+    const UserStats = () => (
+      <Card title="Users" extra={<Icon type="user" />}>
+        <Row gutter={16}>
+          {user.isAdmin ? (
+            <div>
+              <Col span={12}>
+                <Statistic style={{ textAlign: 'center' }} title="Total" value={allUsers.items.length} />
+              </Col>
+              <Col span={12}>
+                <Statistic style={{ textAlign: 'center' }} title="Admins" value={adminMembers.items.length} />
+              </Col>
+            </div>
+          ) : (
+            <Col span={24}>
+              <Statistic style={{ textAlign: 'center' }} title="Total" value={allUsers.items.length} />
+            </Col>
+          )}
+        </Row>
+      </Card>
+    )
+
+    const AdminView = () => (
+      <div>
+        <IntegrationWarning/>
+        <NoTeamInfoAlert />
+        <Row gutter={16} type="flex" style={{ marginTop: '40px', marginBottom: '40px' }}>
+          <Col span={8}>
+            <TeamStats />
+          </Col>
+          <Col span={8}>
+            <UserStats />
+          </Col>
+          <Col span={8}>
+            <Card title="Integrations" extra={<Icon type="api" />}>
+              <Row gutter={16}>
+                <Col span={12}>
+                  <Statistic style={{ textAlign: 'center' }} title="GKE" value={gkeCredentials.items.length} valueStyle={{ color: integrationMissing ? 'orange' : '' }} />
+                </Col>
+                <Col span={12}>
+                  <Statistic style={{ textAlign: 'center' }} title="EKS" value="0" />
+                </Col>
+              </Row>
+            </Card>
+          </Col>
+        </Row>
+      </div>
+    )
+
+    const UserView = () => (
+      <div>
+        <NoTeamInfoAlert />
+        <Row gutter={16} type="flex" style={{ marginTop: '40px', marginBottom: '40px' }}>
+          <Col span={8}>
+            <TeamStats />
+          </Col>
+          <Col span={5}>
+            <UserStats />
+          </Col>
+        </Row>
+      </div>
+    )
+
+    return (
+      <div>
+        <Title level={1} style={{ marginBottom: '0' }}>Appvia Kore</Title>
+        <Title level={4} type="secondary" style={{ marginTop: '10px' }}>Kubernetes for Teams, Making Cloud Simple for Developers and DevOps</Title>
+        {user.isAdmin ? <AdminView /> : <UserView />}
+      </div>
+    )
+  }
 }
 
 export default IndexPage

--- a/server/controllers/auth-openid.js
+++ b/server/controllers/auth-openid.js
@@ -19,7 +19,10 @@ function getLogin(authService, embeddedAuth) {
 }
 
 function getLoginRefresh(req, res) {
-  const authProvider = req.session.authProvider
+  const { localUser, authProvider } = req.session
+  if (localUser) {
+    return res.redirect('/login/process')
+  }
   const authUrl = `/login/auth${authProvider ? `?provider=${authProvider}` : ''}`
   return res.redirect(authUrl)
 }


### PR DESCRIPTION
* showing stats about teams, users and integrations
* more details are shown to admins

Other minor fixes

* fixing default export for `api-request`
* linking `Kore` on top-left to `/`
* don't send a local user through the IDP if refreshing

**Admin user**

<img width="1339" alt="Screen Shot 2020-02-21 at 15 48 17" src="https://user-images.githubusercontent.com/1334068/75049627-76199c80-54c2-11ea-82f4-8a420bad84de.png">

**User**

<img width="1339" alt="Screen Shot 2020-02-21 at 15 29 14" src="https://user-images.githubusercontent.com/1334068/75049642-7b76e700-54c2-11ea-9080-02ea475b4a8d.png">
