### PR TITLE
Fixes for team name translation to k8s friendly name

### DIFF
--- a/lib/utils/canonical.js
+++ b/lib/utils/canonical.js
@@ -1,1 +1,1 @@
-module.exports = (string) => string.replace(/[^a-zA-Z0-9\s]/g, '').replace(/\W/g, '-').toLowerCase()
+module.exports = string => string.replace(/[^a-zA-Z0-9-_\s]/g, '').replace(/\W+/g, '-').toLowerCase()

--- a/pages/teams/[name].js
+++ b/pages/teams/[name].js
@@ -189,7 +189,10 @@ class TeamDashboard extends React.Component {
     return (
       <div>
         <Breadcrumb items={[{text: team.spec.summary}]} />
-        <Paragraph strong>{team.spec.description}</Paragraph>
+        <Paragraph>
+          <Text strong>{team.spec.description}</Text>
+          <Text style={{ float: 'right' }}><Text strong>Short name: </Text>{team.metadata.name}</Text>
+        </Paragraph>
         <Card
           title={<div><Text style={{ marginRight: '10px' }}>Team members</Text><Badge style={{ backgroundColor: '#1890ff' }} count={members.items.length} /></div>}
           style={{ marginBottom: '16px' }}


### PR DESCRIPTION
* retain `_` and `-`
* multiple spaces translated to a single `-`
* expose k8s friendly name as `Short name`