### PR TITLE
Allowing cluster name to be edited

### DIFF
--- a/lib/components/cluster-build/ClusterOptionsForm.js
+++ b/lib/components/cluster-build/ClusterOptionsForm.js
@@ -1,6 +1,5 @@
 import * as React from 'react'
 import PropTypes from 'prop-types'
-import copy from '../../utils/object-copy'
 
 import { Typography, Form, Select, Card, Radio, Table, Modal, Input } from 'antd'
 const { Text, Title } = Typography
@@ -15,83 +14,68 @@ class ClusterOptionsForm extends React.Component {
     teamClusters: PropTypes.array.isRequired
   }
 
-  state = {
-    selectedProvider: this.props.providers.length === 1 ? this.props.providers[0] : false,
-    selectedPlan: false,
-    clusterName: false
-  }
-
-  onProviderChange = value => {
-    const state = copy(this.state)
-    state.selectedProvider = this.props.providers.find(p => p.metadata.name === value)
-    this.setState(state)
-  }
-
   onPlanChange = e => {
-    const state = copy(this.state)
-    state.selectedPlan = this.props.plans.find(p => p.metadata.name === e.target.value)
-    let clusterName = `${this.props.team.metadata.name}-${state.selectedPlan.metadata.name}`
-    const matchingCluster = this.props.teamClusters.find(tc => tc.metadata.name === clusterName)
-    if (matchingCluster) {
-      clusterName = `${clusterName}-2`
+    if (this.props.form.getFieldValue('clusterName')) {
+      this.props.form.setFieldsValue({ 'clusterName': this.generateClusterName(e.target.value) })
     }
-    state.clusterName = clusterName
-    if (this.props.form.getFieldValue('cluster-name')) {
-      this.props.form.setFieldsValue({ 'cluster-name': state.clusterName })
-    }
-    this.setState(state)
   }
 
-  showPlanDetails = () => {
-    const selectedPlan = this.state.selectedPlan
-    const planColumns = [{
-      title: 'Property',
-      dataIndex: 'property',
-      key: 'property',
-    }, {
-      title: 'Value',
-      dataIndex: 'value',
-      key: 'value',
-    }]
-    const planValues = selectedPlan ?
-      Object.keys(selectedPlan.spec.values).map(key => {
-        let value = selectedPlan.spec.values[key]
-        if (key === 'authorizedMasterNetworks') {
-          const complexValue = selectedPlan.spec.values[key]
-          value = `${complexValue[0].name}: ${complexValue[0].cidr}`
-        }
-        return {
-          key,
-          property: key,
-          value: `${value}`
-        }
-      }) :
-      null
-    Modal.info({
-      title: (<div><Title level={4}>{selectedPlan.spec.description}</Title><Text>{selectedPlan.spec.summary}</Text></div>),
-      content: (
-        <Table
-          size="small"
-          pagination={false}
-          columns={planColumns}
-          dataSource={planValues}
-        />
-      ),
-      width: 700,
-      onOk() {}
-    })
+  generateClusterName = selectedPlan => {
+    let clusterName = `${this.props.team.metadata.name}-${selectedPlan}`
+    const matchingClusters = this.props.teamClusters.filter(tc => tc.metadata.name.indexOf(clusterName) === 0)
+    if (matchingClusters.length) {
+      clusterName = `${clusterName}-${matchingClusters.length + 1}`
+    }
+    return clusterName
   }
 
-  clusterNameChanged = e => {
-    const state = copy(this.state)
-    state.clusterName = e.target.value
-    this.setState(state)
+  showPlanDetails = planName => {
+    return () => {
+      const selectedPlan = this.props.plans.find(p => p.metadata.name === planName)
+      const planColumns = [{
+        title: 'Property',
+        dataIndex: 'property',
+        key: 'property',
+      }, {
+        title: 'Value',
+        dataIndex: 'value',
+        key: 'value',
+      }]
+      const planValues = selectedPlan ?
+        Object.keys(selectedPlan.spec.values).map(key => {
+          let value = selectedPlan.spec.values[key]
+          if (key === 'authorizedMasterNetworks') {
+            const complexValue = selectedPlan.spec.values[key]
+            value = `${complexValue[0].name}: ${complexValue[0].cidr}`
+          }
+          return {
+            key,
+            property: key,
+            value: `${value}`
+          }
+        }) :
+        null
+      Modal.info({
+        title: (<div><Title level={4}>{selectedPlan.spec.description}</Title><Text>{selectedPlan.spec.summary}</Text></div>),
+        content: (
+          <Table
+            size="small"
+            pagination={false}
+            columns={planColumns}
+            dataSource={planValues}
+          />
+        ),
+        width: 700,
+        onOk() {}
+      })
+    }
   }
 
   render() {
-    const { getFieldDecorator } = this.props.form
+    const { getFieldDecorator, getFieldValue } = this.props.form
     const { providers, plans } = this.props
-    const { selectedProvider, selectedPlan, clusterName } = this.state
+    const selectedPlan = getFieldValue('plan')
+
     const checkForDuplicateName = (rule, value) => {
       const matchingCluster = this.props.teamClusters.find(tc => tc.metadata.name === value)
       if (!matchingCluster) {
@@ -105,12 +89,9 @@ class ClusterOptionsForm extends React.Component {
         <Form.Item label="Provider">
           {getFieldDecorator('provider', {
             rules: [{ required: true, message: 'Please select your provider!' }],
-            initialValue: selectedProvider ? selectedProvider.metadata.name : undefined
+            initialValue: providers.length === 1 ? providers[0].metadata.name : undefined
           })(
-            <Select
-              placeholder="Provider"
-              onChange={this.onProviderChange}
-            >
+            <Select placeholder="Provider">
               {providers.map(provider => <Option key={provider.metadata.name} value={provider.metadata.name}>{provider.spec.name} - {provider.spec.summary}</Option>)}
             </Select>
           )}
@@ -126,25 +107,23 @@ class ClusterOptionsForm extends React.Component {
             </Radio.Group>
           )}
           {selectedPlan ?
-            <a style={{marginLeft: '20px'}} onClick={this.showPlanDetails}>View plan details</a> :
+            <a style={{marginLeft: '20px'}} onClick={this.showPlanDetails(selectedPlan)}>View plan details</a> :
             null
           }
         </Form.Item>
         {selectedPlan ? (
-          <div>
-            <Form.Item label="Cluster name">
-              {getFieldDecorator('cluster-name', {
-                rules: [
-                  { required: true, message: 'Please enter cluster name!' },
-                  { pattern: '^[a-z][a-z0-9-]{0,38}[a-z0-9]$', message: 'Name must consist of lower case alphanumeric characters or "-", it must start with a letter and end with an alphanumeric and must be no longer than 40 characters' },
-                  { validator: checkForDuplicateName }
-                ],
-                initialValue: clusterName
-              })(
-                <Input onChange={this.clusterNameChanged} />
-              )}
-            </Form.Item>
-          </div>
+          <Form.Item label="Cluster name">
+            {getFieldDecorator('clusterName', {
+              rules: [
+                { required: true, message: 'Please enter cluster name!' },
+                { pattern: '^[a-z][a-z0-9-]{0,38}[a-z0-9]$', message: 'Name must consist of lower case alphanumeric characters or "-", it must start with a letter and end with an alphanumeric and must be no longer than 40 characters' },
+                { validator: checkForDuplicateName }
+              ],
+              initialValue: this.generateClusterName(selectedPlan)
+            })(
+              <Input />
+            )}
+          </Form.Item>
         ) : null}
       </Card>
     )

--- a/lib/components/cluster-build/ClusterOptionsForm.js
+++ b/lib/components/cluster-build/ClusterOptionsForm.js
@@ -2,7 +2,7 @@ import * as React from 'react'
 import PropTypes from 'prop-types'
 import copy from '../../utils/object-copy'
 
-import { Typography, Form, Select, Alert, Card, Radio, List, Table, Modal } from 'antd'
+import { Typography, Form, Select, Card, Radio, Table, Modal, Input } from 'antd'
 const { Text, Title } = Typography
 const { Option } = Select
 
@@ -17,7 +17,8 @@ class ClusterOptionsForm extends React.Component {
 
   state = {
     selectedProvider: this.props.providers.length === 1 ? this.props.providers[0] : false,
-    selectedPlan: false
+    selectedPlan: false,
+    clusterName: false
   }
 
   onProviderChange = value => {
@@ -29,23 +30,16 @@ class ClusterOptionsForm extends React.Component {
   onPlanChange = e => {
     const state = copy(this.state)
     state.selectedPlan = this.props.plans.find(p => p.metadata.name === e.target.value)
-    this.setState(state)
-  }
-
-  matchingClusters = (clusterName) => this.props.teamClusters.filter(tc => tc.metadata.name.indexOf(clusterName) >= 0)
-
-  rawClusterName = () => this.state.selectedPlan && this.state.selectedProvider ?
-    `${this.state.selectedProvider.metadata.name}-${this.props.team.metadata.name}-${this.state.selectedPlan.metadata.name}` :
-    ''
-
-  generateClusterName = () => {
-    let clusterName = this.rawClusterName()
-    const matchingClusters = this.matchingClusters(clusterName)
-    const matchingClusterCount = matchingClusters.length
-    if (matchingClusterCount) {
-      clusterName = `${clusterName}-${matchingClusterCount + 1}`
+    let clusterName = `${this.props.team.metadata.name}-${state.selectedPlan.metadata.name}`
+    const matchingCluster = this.props.teamClusters.find(tc => tc.metadata.name === clusterName)
+    if (matchingCluster) {
+      clusterName = `${clusterName}-2`
     }
-    return clusterName
+    state.clusterName = clusterName
+    if (this.props.form.getFieldValue('cluster-name')) {
+      this.props.form.setFieldsValue({ 'cluster-name': state.clusterName })
+    }
+    this.setState(state)
   }
 
   showPlanDetails = () => {
@@ -88,14 +82,23 @@ class ClusterOptionsForm extends React.Component {
     })
   }
 
+  clusterNameChanged = e => {
+    const state = copy(this.state)
+    state.clusterName = e.target.value
+    this.setState(state)
+  }
+
   render() {
     const { getFieldDecorator } = this.props.form
-
     const { providers, plans } = this.props
-    const { selectedProvider, selectedPlan } = this.state
-    const availablePlans = plans
-    const clusterName = this.generateClusterName()
-    const matchingClusters = this.matchingClusters(this.rawClusterName())
+    const { selectedProvider, selectedPlan, clusterName } = this.state
+    const checkForDuplicateName = (rule, value) => {
+      const matchingCluster = this.props.teamClusters.find(tc => tc.metadata.name === value)
+      if (!matchingCluster) {
+        return Promise.resolve()
+      }
+      return Promise.reject('This name is already used!')
+    }
 
     return (
       <Card title="Choose a provider and plan">
@@ -117,7 +120,7 @@ class ClusterOptionsForm extends React.Component {
             rules: [{ required: true, message: 'Please select your plan!' }],
           })(
             <Radio.Group onChange={this.onPlanChange}>
-              {availablePlans.map((p, idx) => (
+              {plans.map((p, idx) => (
                 <Radio.Button key={idx} value={p.metadata.name}>{p.spec.description}</Radio.Button>
               ))}
             </Radio.Group>
@@ -127,30 +130,20 @@ class ClusterOptionsForm extends React.Component {
             null
           }
         </Form.Item>
-
-        {selectedPlan && selectedProvider ? (
+        {selectedPlan ? (
           <div>
-            <Form.Item label="Cluster name" style={{ marginBottom: '0'}}>
-              <Text>{clusterName}</Text>
+            <Form.Item label="Cluster name">
+              {getFieldDecorator('cluster-name', {
+                rules: [
+                  { required: true, message: 'Please enter cluster name!' },
+                  { pattern: '^[a-z][a-z0-9-]{0,38}[a-z0-9]$', message: 'Name must consist of lower case alphanumeric characters or "-", it must start with a letter and end with an alphanumeric and must be no longer than 40 characters' },
+                  { validator: checkForDuplicateName }
+                ],
+                initialValue: clusterName
+              })(
+                <Input onChange={this.clusterNameChanged} />
+              )}
             </Form.Item>
-            {matchingClusters.length > 0 ? (
-              <Alert
-                message={`Existing clusters matching "${this.state.selectedPlan.spec.description}" plan`}
-                description={
-                  <List
-                    size="small"
-                    dataSource={matchingClusters}
-                    renderItem={cluster => (
-                      <List.Item>
-                        <Text>{cluster.metadata.name}</Text>
-                      </List.Item>
-                    )}
-                  />
-                }
-                type="info"
-                style={{ marginTop: '20px'}}
-              />
-            ) : null}
           </div>
         ) : null}
       </Card>

--- a/lib/components/forms/ClusterBuildForm.js
+++ b/lib/components/forms/ClusterBuildForm.js
@@ -83,9 +83,9 @@ class ClusterBuildForm extends React.Component {
 
         const canonicalTeamName = this.props.team.metadata.name
         const selectedCloud = this.state.selectedCloud
-        const selectedProvider = this.clusterOptionsForm.state.selectedProvider
-        const selectedPlan = this.clusterOptionsForm.state.selectedPlan
-        const clusterName = this.clusterOptionsForm.generateClusterName()
+        const selectedProvider = this.state.providers[selectedCloud].find(p => p.metadata.name === values.provider)
+        const selectedPlan = this.state.plans.items.find(p => p.metadata.name === values.plan)
+        const clusterName = values.clusterName
 
         const showKubernetesOptions = this.state.showKubernetesOptions
 


### PR DESCRIPTION
* defaulting to `team-name-plan-name` pattern
* this is the default value of the input which can now be over-typed
* it is reverted to the default if a different plan is selected
* adding custom validation to ensure the cluster name is unique for the team

<img width="1270" alt="Screen Shot 2020-03-10 at 09 23 51" src="https://user-images.githubusercontent.com/1334068/76298111-dc6b3100-62b0-11ea-818e-41d60fcb0a2c.png">

Closes #63 