### PR TITLE
Resource state fixes

### DIFF
--- a/lib/components/ResourceStatusTag.js
+++ b/lib/components/ResourceStatusTag.js
@@ -7,19 +7,20 @@ const ResourceStatusTag = ({ resourceStatus }) => {
   const status = resourceStatus.status || 'Pending'
   const components = resourceStatus.components
   const conditions = resourceStatus.conditions
+  const inProgressStatusList = ['Pending', 'Deleting']
 
-  const statusTag = <Tag color={statusColorMap[status] || 'red'}>{status === 'Pending' ? <Icon type="loading" /> : null} {status}</Tag>
+  const statusTag = <Tag color={statusColorMap[status] || 'red'}>{inProgressStatusList.includes(status) ? <Icon type="loading" /> : null} {status}</Tag>
 
   if (components) {
     return (
       <Popover placement="left" content={
         <Timeline
-          pending={!status || status === 'Pending'}
+          pending={!status || inProgressStatusList.includes(status)}
           style={{
             marginTop: '25px',
             marginLeft: '10px',
             marginRight: '10px',
-            marginBottom: status !== 'Pending' ? '-30px' : '0'
+            marginBottom: !inProgressStatusList.includes(status) ? '-30px' : '0'
           }}>
           {components.map((c, idx) =>
             <Timeline.Item key={idx} color={statusColorMap[c.status] || 'red'}>

--- a/lib/components/forms/ClusterBuildForm.js
+++ b/lib/components/forms/ClusterBuildForm.js
@@ -86,42 +86,49 @@ class ClusterBuildForm extends React.Component {
         const selectedProvider = this.state.providers[selectedCloud].find(p => p.metadata.name === values.provider)
         const selectedPlan = this.state.plans.items.find(p => p.metadata.name === values.plan)
         const clusterName = values.clusterName
-
         const showKubernetesOptions = this.state.showKubernetesOptions
 
-        const gkeSpec = {
-          description: selectedPlan.spec.description,
-          ...selectedPlan.spec.values,
-          credentials: selectedProvider.spec.resource
-        }
-        const apiVersion = `${selectedProvider.spec.resource.group}/${selectedProvider.spec.resource.version}`
-        const clusterResource = Generic({
-          apiVersion,
-          kind: selectedCloud,
-          name: clusterName,
-          spec: gkeSpec
-        })
-        const k8sSpec = {
-          inheritTeamMembers: true,
-          defaultTeamRole: 'cluster-admin',
-          provider: selectedProvider.spec.resource,
-          enableDefaultTrafficBlock: false
-        }
-        if (showKubernetesOptions) {
-          showKubernetesOptions.domain = values.domain
-        }
-        const k8sResource = Generic({
-          apiVersion: 'clusters.compute.kore.appvia.io/v1alpha1',
-          kind: 'Kubernetes',
-          name: clusterName,
-          spec: k8sSpec
-        })
+        const providerPath = {
+          'GKE': 'gkes',
+          'EKS': 'ekss'
+        }[selectedCloud]
+
         try {
-          const providerPath = {
-            'GKE': 'gkes',
-            'EKS': 'ekss'
-          }[selectedCloud]
-          await apiRequest(null, 'put', `/teams/${canonicalTeamName}/${providerPath}/${clusterName}`, clusterResource)
+          const gkeSpec = {
+            description: selectedPlan.spec.description,
+            ...selectedPlan.spec.values,
+            credentials: selectedProvider.spec.resource
+          }
+          const apiVersion = `${selectedProvider.spec.resource.group}/${selectedProvider.spec.resource.version}`
+          const clusterResource = Generic({
+            apiVersion,
+            kind: selectedCloud,
+            name: clusterName,
+            spec: gkeSpec
+          })
+          const providerResult = await apiRequest(null, 'put', `/teams/${canonicalTeamName}/${providerPath}/${clusterName}`, clusterResource)
+          const k8sSpec = {
+            inheritTeamMembers: true,
+            defaultTeamRole: 'cluster-admin',
+            provider: {
+              group: selectedProvider.spec.resource.group,
+              version: selectedProvider.spec.resource.version,
+              kind: selectedCloud,
+              name: providerResult.metadata.name,
+              namespace: providerResult.metadata.namespace
+            },
+            enableDefaultTrafficBlock: false
+          }
+          if (showKubernetesOptions) {
+            showKubernetesOptions.domain = values.domain
+          }
+          const k8sResource = Generic({
+            apiVersion: 'clusters.compute.kore.appvia.io/v1alpha1',
+            kind: 'Kubernetes',
+            name: clusterName,
+            spec: k8sSpec
+          })
+
           await apiRequest(null, 'put', `/teams/${canonicalTeamName}/clusters/${clusterName}`, k8sResource)
           message.loading('Cluster build requested...')
           return redirect(null, `/teams/${canonicalTeamName}`)

--- a/lib/components/team/AutoRefreshComponent.js
+++ b/lib/components/team/AutoRefreshComponent.js
@@ -14,12 +14,18 @@ class AutoRefreshComponent extends React.Component {
   FINAL_STATES = ['Success', 'Failure']
 
   isFinalState() {
-    return this.FINAL_STATES.includes(this.state[this.stateResourceDataKey].status.status)
+    const status = this.state[this.stateResourceDataKey].status && this.state[this.stateResourceDataKey].status.status
+    return this.FINAL_STATES.includes(status)
+  }
+
+  isDeleted() {
+    return this.state[this.stateResourceDataKey].deleted
   }
 
   checkClearInterval() {
-    if (this.isFinalState()) {
-      this.showMessage && this.showMessage(this.state[this.stateResourceDataKey].status.status)
+    if (this.isDeleted() || this.isFinalState()) {
+      const status = this.state[this.stateResourceDataKey].status ? this.state[this.stateResourceDataKey].status.status : 'Deleted'
+      this.finalStateReached && this.finalStateReached(status)
       clearInterval(this.interval)
     }
   }
@@ -29,16 +35,23 @@ class AutoRefreshComponent extends React.Component {
     return resourceData
   }
 
-  componentDidMount() {
-    if (!this.isFinalState()) {
+  startRefreshing() {
+    if (!this.isFinalState() && !this.isDeleted()) {
       this.interval = setInterval(async () => {
         const resourceData = await this.fetchResource()
+        if (Object.keys(resourceData).length === 0) {
+          resourceData.deleted = true
+        }
         const state = copy(this.state)
         state[this.stateResourceDataKey] = resourceData
         this.setState(state)
         this.checkClearInterval()
       }, this.refreshMs)
     }
+  }
+
+  componentDidMount() {
+    this.startRefreshing()
   }
 
   componentWillUnmount() {

--- a/lib/components/team/Cluster.js
+++ b/lib/components/team/Cluster.js
@@ -12,28 +12,34 @@ import AutoRefreshComponent from './AutoRefreshComponent'
 class Cluster extends AutoRefreshComponent {
   static propTypes = {
     team: PropTypes.string.isRequired,
-    provider: PropTypes.object.isRequired,
     cluster: PropTypes.object.isRequired,
-    namespaceClaims: PropTypes.array.isRequired
+    namespaceClaims: PropTypes.array.isRequired,
+    handleDelete: PropTypes.func
   }
 
   constructor(props) {
     super(props)
     this.state = {
-      cluster: this.props.cluster
+      cluster: this.props.cluster,
+      name: this.props.cluster.metadata.name
     }
     this.refreshMs = 10000
     this.stateResourceDataKey = 'cluster'
     this.resourceApiPath = `/teams/${props.team}/clusters/${props.cluster.metadata.name}`
   }
 
-  showMessage(status) {
-    const cluster = this.state.cluster
+  finalStateReached(status) {
+    const { cluster, name } = this.state
     if (status === 'Success') {
       message.success(`Cluster successfully created: ${cluster.metadata.name}`)
     }
     if (status === 'Failure') {
       message.error(`Cluster failed to create: ${cluster.metadata.name}`)
+    }
+    if (status === 'Deleted') {
+      const { handleDelete } = this.props
+      handleDelete && handleDelete(name)
+      message.success(`Cluster successfully deleted: ${name}`)
     }
   }
 
@@ -61,9 +67,10 @@ class Cluster extends AutoRefreshComponent {
       const state = copy(this.state)
       const cluster = state.cluster
       await apiRequest(null, 'delete', `/teams/${team}/clusters/${cluster.metadata.name}`)
-      await apiRequest(null, 'delete', `/teams/${team}/gkes/${cluster.metadata.name}`)
-      state.cluster.deleted = true
+      cluster.status.status = 'Deleting'
+      cluster.metadata.deletionTimestamp = new Date()
       this.setState(state)
+      this.startRefreshing()
       message.loading(`Cluster deletion requested: ${cluster.metadata.name}`)
     } catch (err) {
       console.error('Error deleting cluster', err)
@@ -73,13 +80,13 @@ class Cluster extends AutoRefreshComponent {
 
   render() {
     const { cluster } = this.state
-    const { provider } = this.props
 
     if (cluster.deleted) {
       return null
     }
 
     const created = moment(cluster.metadata.creationTimestamp).fromNow()
+    const deleted = cluster.metadata.deletionTimestamp ? moment(cluster.metadata.deletionTimestamp).fromNow() : false
 
     const actions = () => {
       const actions = []
@@ -107,9 +114,14 @@ class Cluster extends AutoRefreshComponent {
     return (
       <List.Item actions={actions()}>
         <List.Item.Meta
-          avatar={<img src={clusterProviderIconSrcMap[provider.spec.resource.kind]} height="32px" />}
-          title={<Text>{provider.spec.name} <Text style={{ fontFamily: 'monospace', marginLeft: '15px' }}>{cluster.metadata.name}</Text></Text>}
-          description={<Text type='secondary'>Created {created}</Text>}
+          avatar={<img src={clusterProviderIconSrcMap[cluster.spec.provider.kind]} height="32px" />}
+          title={<Text>{cluster.spec.provider.kind} <Text style={{ fontFamily: 'monospace', marginLeft: '15px' }}>{cluster.metadata.name}</Text></Text>}
+          description={
+            <div>
+              <Text type='secondary'>Created {created}</Text>
+              {deleted ? <Text type='secondary'><br/>Deleted {deleted}</Text> : null }
+            </div>
+          }
         />
       </List.Item>
     )

--- a/lib/components/team/NamespaceClaim.js
+++ b/lib/components/team/NamespaceClaim.js
@@ -18,33 +18,40 @@ class NamespaceClaim extends AutoRefreshComponent {
   constructor(props) {
     super(props)
     this.state = {
-      namespaceClaim: props.namespaceClaim
+      namespaceClaim: props.namespaceClaim,
+      name: props.namespaceClaim.metadata.name
     }
-    this.refreshMs = 2000
+    this.refreshMs = 15000
     this.stateResourceDataKey = 'namespaceClaim'
     this.resourceApiPath = `/teams/${props.team}/namespaceclaims/${props.namespaceClaim.metadata.name}`
   }
 
-  showMessage(status) {
-    const namespaceClaim = this.state.namespaceClaim
+  finalStateReached(status) {
+    const { namespaceClaim, name } = this.state
     if (status === 'Success') {
       message.success(`Namespace "${namespaceClaim.spec.name}" created on cluster "${namespaceClaim.spec.cluster.name}"`)
     }
     if (status === 'Failure') {
       message.error(`Namespace "${namespaceClaim.spec.name}" failed to create on cluster "${namespaceClaim.spec.cluster.name}"`)
     }
+    if (status === 'Deleted') {
+      const { handleDelete } = this.props
+      handleDelete && handleDelete(name)
+      message.success(`Namespace "${name}" successfully deleted`)
+    }
   }
 
   deleteResource = async () => {
-    const { team, handleDelete } = this.props
+    const { team } = this.props
     try {
       const state = copy(this.state)
       const namespaceClaim = state.namespaceClaim
       await apiRequest(null, 'delete', `/teams/${team}/namespaceclaims/${state.namespaceClaim.metadata.name}`)
-      state.namespaceClaim.deleted = true
+      namespaceClaim.status.status = 'Deleting'
+      namespaceClaim.metadata.deletionTimestamp = new Date()
       this.setState(state)
-      handleDelete && handleDelete(namespaceClaim)
-      message.success(`Namespace deleted: ${state.namespaceClaim.spec.name}`)
+      this.startRefreshing()
+      message.loading(`Namespace deletion requested: ${namespaceClaim.metadata.name}`)
     } catch (err) {
       console.error('Error deleting namespace', err)
       message.error('Error deleting namespace, please try again.')
@@ -60,6 +67,7 @@ class NamespaceClaim extends AutoRefreshComponent {
 
     const clusterName = namespaceClaim.spec.cluster.name
     const created = moment(namespaceClaim.metadata.creationTimestamp).fromNow()
+    const deleted = namespaceClaim.metadata.deletionTimestamp ? moment(namespaceClaim.metadata.deletionTimestamp).fromNow() : false
 
     const actions = () => {
       const actions = []
@@ -87,7 +95,12 @@ class NamespaceClaim extends AutoRefreshComponent {
         <List.Item.Meta
           avatar={<Avatar icon="block" />}
           title={<Text>{namespaceClaim.metadata.name} <Text style={{ fontFamily: 'monospace', marginLeft: '15px' }}>{clusterName}</Text></Text>}
-          description={<div><Text type='secondary'>Created {created}</Text></div>}
+          description={
+            <div>
+              <Text type='secondary'>Created {created}</Text>
+              {deleted ? <Text type='secondary'><br/>Deleted {deleted}</Text> : null }
+            </div>
+          }
         />
       </List.Item>
     )

--- a/lib/utils/ui-helpers.js
+++ b/lib/utils/ui-helpers.js
@@ -4,7 +4,7 @@ module.exports = {
     'Pending': 'orange'
   },
   clusterProviderIconSrcMap: {
-    'GKECredentials': '/static/images/GKE.png',
-    'EKSCredentials': '/static/images/EKS.png'
+    'GKE': '/static/images/GKE.png',
+    'EKS': '/static/images/EKS.png'
   }
 }


### PR DESCRIPTION
* create cluster resource fix for `spec.provider` - it should be the `GKE` resource not `GKECredentials`
* deleting clusters now auto refreshes and the row is removed when it's deleted
* same with namespace claims
* showing deleted time when it's available

Closes #61 
Closes #64
Closes #67 
Closes #70 