### PR TITLE
Team page resource updates

### DIFF
--- a/__tests__/pages/teams/[name].test.js
+++ b/__tests__/pages/teams/[name].test.js
@@ -39,8 +39,10 @@ describe('TeamPage', () => {
 
     describe('#constructor', () => {
       it('sets props on state', () => {
-        expect(teamPage.state.teamName).toBe('a-team')
-        expect(teamPage.state.members).toEqual({ items: ['jbloggs', 'fflintstone'] })
+        expect(teamPage.state.members).toEqual(props.members)
+        expect(teamPage.state.clusters).toEqual(props.clusters)
+        expect(teamPage.state.namespaceClaims).toEqual(props.namespaceClaims)
+        expect(teamPage.state.createNamespace).toEqual(false)
       })
     })
 

--- a/lib/components/team/Cluster.js
+++ b/lib/components/team/Cluster.js
@@ -28,6 +28,14 @@ class Cluster extends AutoRefreshComponent {
     this.resourceApiPath = `/teams/${props.team}/clusters/${props.cluster.metadata.name}`
   }
 
+  componentDidUpdate() {
+    if (this.state.cluster && this.state.cluster !== this.props.cluster) {
+      const state = copy(this.state)
+      state.cluster = this.props.cluster
+      this.setState(state)
+    }
+  }
+
   finalStateReached(status) {
     const { cluster, name } = this.state
     if (status === 'Success') {

--- a/lib/components/team/InviteLink.js
+++ b/lib/components/team/InviteLink.js
@@ -19,20 +19,27 @@ class InviteLink extends React.Component {
 
   async fetchComponentData() {
     const inviteLink = await apiRequest(null, 'get', `/teams/${this.props.team}/invites/generate`)
-    return inviteLink
+    const state = copy(this.state)
+    if (typeof inviteLink !== 'string') {
+      state.dataError = true
+    }
+    state.inviteLink = inviteLink
+    state.dataLoading = false
+    this.setState(state)
   }
 
   componentDidMount() {
-    return this.fetchComponentData()
-      .then(inviteLink => {
-        const state = copy(this.state)
-        if (typeof inviteLink !== 'string') {
-          state.dataError = true
-        }
-        state.inviteLink = inviteLink
-        state.dataLoading = false
-        this.setState(state)
-      })
+    this.fetchComponentData()
+  }
+
+  componentDidUpdate(prevProps) {
+    if (prevProps.team !== this.props.team) {
+      const state = copy(this.state)
+      state.dataLoading = true
+      this.setState(state)
+
+      this.fetchComponentData()
+    }
   }
 
   copyInviteLink = () => {

--- a/lib/components/team/NamespaceClaim.js
+++ b/lib/components/team/NamespaceClaim.js
@@ -26,6 +26,14 @@ class NamespaceClaim extends AutoRefreshComponent {
     this.resourceApiPath = `/teams/${props.team}/namespaceclaims/${props.namespaceClaim.metadata.name}`
   }
 
+  componentDidUpdate() {
+    if (this.state.namespaceClaim && this.state.namespaceClaim !== this.props.namespaceClaim) {
+      const state = copy(this.state)
+      state.namespaceClaim = this.props.namespaceClaim
+      this.setState(state)
+    }
+  }
+
   finalStateReached(status) {
     const { namespaceClaim, name } = this.state
     if (status === 'Success') {

--- a/pages/teams/[name].js
+++ b/pages/teams/[name].js
@@ -33,7 +33,6 @@ class TeamDashboard extends React.Component {
   constructor(props) {
     super(props)
     this.state = {
-      teamName: props.team.metadata.name,
       members: props.members,
       allUsers: [],
       membersToAdd: [],
@@ -85,13 +84,12 @@ class TeamDashboard extends React.Component {
       })
   }
 
-  componentDidUpdate(props, state) {
-    if (this.props.team.metadata.name !== state.teamName) {
+  componentDidUpdate(prevProps) {
+    if (this.props.team.metadata.name !== prevProps.team.metadata.name) {
       const state = copy(this.state)
-      state.teamName = this.props.team.metadata.name
-      state.members = props.members
-      state.clusters = props.clusters
-      state.namespaceClaims = props.namespaceClaims
+      state.members = this.props.members
+      state.clusters = this.props.clusters
+      state.namespaceClaims = this.props.namespaceClaims
       this.getAllUsers()
         .then(users => {
           state.allUsers = users


### PR DESCRIPTION
Ensuring the resources are properly refreshed when switching between teams

* fixing `componentDidUpdate` in `[name].js` to use new props instead of previous ones
* adding `componentDidUpdate` to `Cluster` and `NamespaceClaim` components in order to update state when props are changed
* same for the `InviteLink` component, a new link should be generated when the team is switched

Closes #77 