### PR TITLE
Team resource fixes

### DIFF
--- a/lib/components/team/AutoRefreshComponent.js
+++ b/lib/components/team/AutoRefreshComponent.js
@@ -15,27 +15,29 @@ class AutoRefreshComponent extends React.Component {
   static propTypes = {
     refreshMs: PropTypes.number.isRequired,
     stateResourceDataKey: PropTypes.string.isRequired,
-    resourceApiPath: PropTypes.string.isRequired
+    resourceApiPath: PropTypes.string.isRequired,
+    handleUpdate: PropTypes.func.isRequired,
+    handleDelete: PropTypes.func.isRequired
   }
 
   FINAL_STATES = ['Success', 'Failure']
 
   isFinalState() {
-    const stateResource = this.state[this.props.stateResourceDataKey]
+    const stateResource = this.props[this.props.stateResourceDataKey]
     const status = stateResource.status && stateResource.status.status
     return this.FINAL_STATES.includes(status)
   }
 
   isDeleted() {
-    return this.state[this.props.stateResourceDataKey].deleted
+    return this.props[this.props.stateResourceDataKey].deleted
   }
 
   checkClearInterval() {
     const isDeleted = this.isDeleted()
     if (isDeleted || this.isFinalState()) {
-      const stateResource = this.state[this.props.stateResourceDataKey]
+      const stateResource = this.props[this.props.stateResourceDataKey]
       const status = isDeleted ? 'Deleted' : (stateResource.status && stateResource.status.status)
-      this.finalStateReached && this.finalStateReached(status)
+      this.finalStateReached && this.finalStateReached()
       clearInterval(this.interval)
     }
   }
@@ -48,13 +50,14 @@ class AutoRefreshComponent extends React.Component {
   startRefreshing() {
     if (!this.isFinalState() && !this.isDeleted()) {
       this.interval = setInterval(async () => {
+        const resourceName = this.props[this.props.stateResourceDataKey].metadata.name
         const resourceData = await this.fetchResource()
         if (Object.keys(resourceData).length === 0) {
           resourceData.deleted = true
+          this.props.handleDelete(resourceName, () => this.checkClearInterval())
+        } else {
+          this.props.handleUpdate(resourceData, () => this.checkClearInterval())
         }
-        const state = copy(this.state)
-        state[this.props.stateResourceDataKey] = resourceData
-        this.setState(state, this.checkClearInterval)
       }, this.props.refreshMs)
     }
   }

--- a/lib/components/team/AutoRefreshComponent.js
+++ b/lib/components/team/AutoRefreshComponent.js
@@ -1,9 +1,10 @@
 import * as React from 'react'
+import PropTypes from 'prop-types'
 import apiRequest from '../../utils/api-request'
 import copy from '../../utils/object-copy'
 
 /*
- Properties that must be set on the parent
+ Props that must be passed to the parent
    - refreshMs - how often to refresh the state
    - stateResourceDataKey - where is the data located in the state object
    - resourceApiPath - API path for requesting updated resource data
@@ -11,28 +12,36 @@ import copy from '../../utils/object-copy'
 
 class AutoRefreshComponent extends React.Component {
 
+  static propTypes = {
+    refreshMs: PropTypes.number.isRequired,
+    stateResourceDataKey: PropTypes.string.isRequired,
+    resourceApiPath: PropTypes.string.isRequired
+  }
+
   FINAL_STATES = ['Success', 'Failure']
 
   isFinalState() {
-    const status = this.state[this.stateResourceDataKey].status && this.state[this.stateResourceDataKey].status.status
+    const stateResource = this.state[this.props.stateResourceDataKey]
+    const status = stateResource.status && stateResource.status.status
     return this.FINAL_STATES.includes(status)
   }
 
   isDeleted() {
-    return this.state[this.stateResourceDataKey].deleted
+    return this.state[this.props.stateResourceDataKey].deleted
   }
 
   checkClearInterval() {
     const isDeleted = this.isDeleted()
     if (isDeleted || this.isFinalState()) {
-      const status = isDeleted ? 'Deleted' : (this.state[this.stateResourceDataKey].status && this.state[this.stateResourceDataKey].status.status)
+      const stateResource = this.state[this.props.stateResourceDataKey]
+      const status = isDeleted ? 'Deleted' : (stateResource.status && stateResource.status.status)
       this.finalStateReached && this.finalStateReached(status)
       clearInterval(this.interval)
     }
   }
 
   async fetchResource() {
-    const resourceData = await apiRequest(null, 'get', this.resourceApiPath)
+    const resourceData = await apiRequest(null, 'get', this.props.resourceApiPath)
     return resourceData
   }
 
@@ -44,9 +53,9 @@ class AutoRefreshComponent extends React.Component {
           resourceData.deleted = true
         }
         const state = copy(this.state)
-        state[this.stateResourceDataKey] = resourceData
-        this.setState(state, () => this.checkClearInterval())
-      }, this.refreshMs)
+        state[this.props.stateResourceDataKey] = resourceData
+        this.setState(state, this.checkClearInterval)
+      }, this.props.refreshMs)
     }
   }
 

--- a/lib/components/team/AutoRefreshComponent.js
+++ b/lib/components/team/AutoRefreshComponent.js
@@ -1,7 +1,6 @@
 import * as React from 'react'
 import PropTypes from 'prop-types'
 import apiRequest from '../../utils/api-request'
-import copy from '../../utils/object-copy'
 
 /*
  Props that must be passed to the parent
@@ -33,10 +32,7 @@ class AutoRefreshComponent extends React.Component {
   }
 
   checkClearInterval() {
-    const isDeleted = this.isDeleted()
-    if (isDeleted || this.isFinalState()) {
-      const stateResource = this.props[this.props.stateResourceDataKey]
-      const status = isDeleted ? 'Deleted' : (stateResource.status && stateResource.status.status)
+    if (this.isDeleted() || this.isFinalState()) {
       this.finalStateReached && this.finalStateReached()
       clearInterval(this.interval)
     }

--- a/lib/components/team/Cluster.js
+++ b/lib/components/team/Cluster.js
@@ -3,8 +3,6 @@ import moment from 'moment'
 import { List, Icon, Typography, Modal, Popconfirm, message } from 'antd'
 const { Text, Paragraph } = Typography
 
-import apiRequest from '../../utils/api-request'
-import copy from '../../utils/object-copy'
 import { clusterProviderIconSrcMap } from '../../utils/ui-helpers'
 import ResourceStatusTag from '../ResourceStatusTag'
 import AutoRefreshComponent from './AutoRefreshComponent'
@@ -14,42 +12,24 @@ class Cluster extends AutoRefreshComponent {
     team: PropTypes.string.isRequired,
     cluster: PropTypes.object.isRequired,
     namespaceClaims: PropTypes.array.isRequired,
-    handleDelete: PropTypes.func
+    deleteCluster: PropTypes.func.isRequired
   }
 
-  constructor(props) {
-    super(props)
-    this.state = {
-      cluster: this.props.cluster,
-      name: this.props.cluster.metadata.name
+  finalStateReached() {
+    const { cluster } = this.props
+    const { status, deleted } = cluster
+    if (deleted) {
+      return message.success(`Cluster successfully deleted: ${cluster.metadata.name}`)
     }
-  }
-
-  componentDidUpdate(prevProps, prevState) {
-    if (prevState.cluster && prevState.cluster !== this.props.cluster) {
-      const state = copy(this.state)
-      state.cluster = this.props.cluster
-      state.name = this.props.cluster.metadata.name
-      this.setState(state)
+    if (status.status === 'Success') {
+      return message.success(`Cluster successfully created: ${cluster.metadata.name}`)
+    }
+    if (status.status === 'Failure') {
+      return message.error(`Cluster failed to create: ${cluster.metadata.name}`)
     }
   }
 
-  finalStateReached(status) {
-    const { cluster, name } = this.state
-    if (status === 'Success') {
-      message.success(`Cluster successfully created: ${cluster.metadata.name}`)
-    }
-    if (status === 'Failure') {
-      message.error(`Cluster failed to create: ${cluster.metadata.name}`)
-    }
-    if (status === 'Deleted') {
-      const { handleDelete } = this.props
-      handleDelete && handleDelete(name)
-      message.success(`Cluster successfully deleted: ${name}`)
-    }
-  }
-
-  deleteResource = async () => {
+  deleteCluster = () => {
     const { namespaceClaims } = this.props
     if (namespaceClaims.length > 0) {
       return Modal.warning({
@@ -60,7 +40,7 @@ class Cluster extends AutoRefreshComponent {
             <List
               size="small"
               dataSource={namespaceClaims}
-              renderItem={ns => <List.Item>{ns.metadata.name}</List.Item>}
+              renderItem={ns => <List.Item>{ns.spec.name}</List.Item>}
             />
           </div>
         ),
@@ -68,23 +48,13 @@ class Cluster extends AutoRefreshComponent {
       })
     }
 
-    const { team } = this.props
-    try {
-      const state = copy(this.state)
-      const cluster = state.cluster
-      await apiRequest(null, 'delete', `/teams/${team}/clusters/${cluster.metadata.name}`)
-      cluster.status.status = 'Deleting'
-      cluster.metadata.deletionTimestamp = new Date()
-      this.setState(state, this.startRefreshing)
-      message.loading(`Cluster deletion requested: ${cluster.metadata.name}`)
-    } catch (err) {
-      console.error('Error deleting cluster', err)
-      message.error('Error deleting cluster, please try again.')
-    }
+    this.props.deleteCluster(this.props.cluster.metadata.name, () => {
+      this.startRefreshing()
+    })
   }
 
   render() {
-    const { cluster } = this.state
+    const { cluster } = this.props
 
     if (cluster.deleted) {
       return null
@@ -102,7 +72,7 @@ class Cluster extends AutoRefreshComponent {
           <Popconfirm
             key="delete"
             title="Are you sure you want to delete this cluster?"
-            onConfirm={this.deleteResource}
+            onConfirm={this.deleteCluster}
             okText="Yes"
             cancelText="No"
           >

--- a/lib/components/team/Cluster.js
+++ b/lib/components/team/Cluster.js
@@ -23,15 +23,13 @@ class Cluster extends AutoRefreshComponent {
       cluster: this.props.cluster,
       name: this.props.cluster.metadata.name
     }
-    this.refreshMs = 10000
-    this.stateResourceDataKey = 'cluster'
-    this.resourceApiPath = `/teams/${props.team}/clusters/${props.cluster.metadata.name}`
   }
 
-  componentDidUpdate() {
-    if (this.state.cluster && this.state.cluster !== this.props.cluster) {
+  componentDidUpdate(prevProps, prevState) {
+    if (prevState.cluster && prevState.cluster !== this.props.cluster) {
       const state = copy(this.state)
       state.cluster = this.props.cluster
+      state.name = this.props.cluster.metadata.name
       this.setState(state)
     }
   }
@@ -77,8 +75,7 @@ class Cluster extends AutoRefreshComponent {
       await apiRequest(null, 'delete', `/teams/${team}/clusters/${cluster.metadata.name}`)
       cluster.status.status = 'Deleting'
       cluster.metadata.deletionTimestamp = new Date()
-      this.setState(state)
-      this.startRefreshing()
+      this.setState(state, this.startRefreshing)
       message.loading(`Cluster deletion requested: ${cluster.metadata.name}`)
     } catch (err) {
       console.error('Error deleting cluster', err)

--- a/lib/components/team/NamespaceClaim.js
+++ b/lib/components/team/NamespaceClaim.js
@@ -22,9 +22,6 @@ class NamespaceClaim extends AutoRefreshComponent {
       name: props.namespaceClaim.spec.name,
       resourceName: props.namespaceClaim.metadata.name
     }
-    this.refreshMs = 15000
-    this.stateResourceDataKey = 'namespaceClaim'
-    this.resourceApiPath = `/teams/${props.team}/namespaceclaims/${props.namespaceClaim.metadata.name}`
   }
 
   componentDidUpdate(prevProps, prevState) {
@@ -60,7 +57,7 @@ class NamespaceClaim extends AutoRefreshComponent {
       await apiRequest(null, 'delete', `/teams/${team}/namespaceclaims/${state.namespaceClaim.metadata.name}`)
       namespaceClaim.status.status = 'Deleting'
       namespaceClaim.metadata.deletionTimestamp = new Date()
-      this.setState(state, () => this.startRefreshing())
+      this.setState(state, this.startRefreshing)
       message.loading(`Namespace deletion requested: ${namespaceClaim.spec.name}`)
     } catch (err) {
       console.error('Error deleting namespace', err)

--- a/lib/components/team/NamespaceClaim.js
+++ b/lib/components/team/NamespaceClaim.js
@@ -10,7 +10,7 @@ class NamespaceClaim extends AutoRefreshComponent {
   static propTypes = {
     team: PropTypes.string.isRequired,
     namespaceClaim: PropTypes.object.isRequired,
-    deleteNamespace: PropTypes.func
+    deleteNamespace: PropTypes.func.isRequired
   }
 
   finalStateReached() {

--- a/lib/components/team/NamespaceClaim.js
+++ b/lib/components/team/NamespaceClaim.js
@@ -3,8 +3,6 @@ import moment from 'moment'
 import { List, Avatar, Icon, Typography, Popconfirm, message } from 'antd'
 const { Text } = Typography
 
-import apiRequest from '../../utils/api-request'
-import copy from '../../utils/object-copy'
 import ResourceStatusTag from '../ResourceStatusTag'
 import AutoRefreshComponent from './AutoRefreshComponent'
 
@@ -12,61 +10,31 @@ class NamespaceClaim extends AutoRefreshComponent {
   static propTypes = {
     team: PropTypes.string.isRequired,
     namespaceClaim: PropTypes.object.isRequired,
-    handleDelete: PropTypes.func
+    deleteNamespace: PropTypes.func
   }
 
-  constructor(props) {
-    super(props)
-    this.state = {
-      namespaceClaim: props.namespaceClaim,
-      name: props.namespaceClaim.spec.name,
-      resourceName: props.namespaceClaim.metadata.name
+  finalStateReached() {
+    const { namespaceClaim } = this.props
+    const { spec, status, deleted } = namespaceClaim
+    if (deleted) {
+      return message.success(`Namespace "${spec.name}" successfully deleted`)
     }
-  }
-
-  componentDidUpdate(prevProps, prevState) {
-    if (prevState.namespaceClaim && prevState.namespaceClaim !== this.props.namespaceClaim) {
-      const state = copy(this.state)
-      state.namespaceClaim = this.props.namespaceClaim
-      state.name = this.props.namespaceClaim.spec.name
-      state.resourceName = this.props.namespaceClaim.metadata.name
-      this.setState(state)
+    if (status.status === 'Success') {
+      return message.success(`Namespace "${spec.name}" created on cluster "${spec.cluster.name}"`)
+    }
+    if (status.status === 'Failure') {
+      return message.error(`Namespace "${spec.name}" failed to create on cluster "${spec.cluster.name}"`)
     }
   }
 
-  finalStateReached(status) {
-    const { namespaceClaim, name, resourceName } = this.state
-    if (status === 'Success') {
-      message.success(`Namespace "${name}" created on cluster "${namespaceClaim.spec.cluster.name}"`)
-    }
-    if (status === 'Failure') {
-      message.error(`Namespace "${name}" failed to create on cluster "${namespaceClaim.spec.cluster.name}"`)
-    }
-    if (status === 'Deleted') {
-      const { handleDelete } = this.props
-      handleDelete && handleDelete(resourceName)
-      message.success(`Namespace "${name}" successfully deleted`)
-    }
-  }
-
-  deleteResource = async () => {
-    const { team } = this.props
-    try {
-      const state = copy(this.state)
-      const namespaceClaim = state.namespaceClaim
-      await apiRequest(null, 'delete', `/teams/${team}/namespaceclaims/${state.namespaceClaim.metadata.name}`)
-      namespaceClaim.status.status = 'Deleting'
-      namespaceClaim.metadata.deletionTimestamp = new Date()
-      this.setState(state, this.startRefreshing)
-      message.loading(`Namespace deletion requested: ${namespaceClaim.spec.name}`)
-    } catch (err) {
-      console.error('Error deleting namespace', err)
-      message.error('Error deleting namespace, please try again.')
-    }
+  deleteNamespace = () => {
+    this.props.deleteNamespace(this.props.namespaceClaim.metadata.name, () => {
+      this.startRefreshing()
+    })
   }
 
   render() {
-    const { namespaceClaim } = this.state
+    const { namespaceClaim } = this.props
 
     if (namespaceClaim.deleted) {
       return null
@@ -84,7 +52,7 @@ class NamespaceClaim extends AutoRefreshComponent {
           <Popconfirm
             key="delete"
             title="Are you sure you want to delete this namespace?"
-            onConfirm={this.deleteResource}
+            onConfirm={this.deleteNamespace}
             okText="Yes"
             cancelText="No"
           >

--- a/pages/teams/[name].js
+++ b/pages/teams/[name].js
@@ -135,18 +135,22 @@ class TeamDashboard extends React.Component {
     }
   }
 
-  handleClusterDeleted = (name, done) => {
-    const state = copy(this.state)
-    const deletedCluster = state.clusters.items.find(c => c.metadata.name === name)
-    deletedCluster.deleted = true
-    this.setState(state, done)
+  handleResourceUpdated = resourceType => {
+    return (updatedResource, done) => {
+      const state = copy(this.state)
+      const resource = state[resourceType].items.find(r => r.metadata.name === updatedResource.metadata.name)
+      resource.status = updatedResource.status
+      this.setState(state, done)
+    }
   }
 
-  handleClusterUpdated = (updatedCluster, done) => {
-    const state = copy(this.state)
-    const cluster = state.clusters.items.find(c => c.metadata.name === updatedCluster.metadata.name)
-    cluster.status = updatedCluster.status
-    this.setState(state, done)
+  handleResourceDeleted = resourceType => {
+    return (name, done) => {
+      const state = copy(this.state)
+      const resource = state[resourceType].items.find(r => r.metadata.name === name)
+      resource.deleted = true
+      this.setState(state, done)
+    }
   }
 
   deleteCluster = async (name, done) => {
@@ -179,20 +183,6 @@ class TeamDashboard extends React.Component {
     state.namespaceClaims.items.push(namespaceClaim)
     this.setState(state)
     message.loading(`Namespace "${namespaceClaim.spec.name}" requested on cluster "${namespaceClaim.spec.cluster.name}"`)
-  }
-
-  handleNamespaceDeleted = (name, done) => {
-    const state = copy(this.state)
-    const deletedNc = state.namespaceClaims.items.find(nc => nc.metadata.name === name)
-    deletedNc.deleted = true
-    this.setState(state, done)
-  }
-
-  handleNamespaceUpdated = (updatedNamespaceClaim, done) => {
-    const state = copy(this.state)
-    const namespaceClaim = state.namespaceClaims.items.find(nc => nc.metadata.name === updatedNamespaceClaim.metadata.name)
-    namespaceClaim.status = updatedNamespaceClaim.status
-    this.setState(state, done)
   }
 
   deleteNamespace = async (name, done) => {
@@ -308,8 +298,8 @@ class TeamDashboard extends React.Component {
                   cluster={cluster}
                   namespaceClaims={namespaceClaims}
                   deleteCluster={this.deleteCluster}
-                  handleUpdate={this.handleClusterUpdated}
-                  handleDelete={this.handleClusterDeleted}
+                  handleUpdate={this.handleResourceUpdated('clusters')}
+                  handleDelete={this.handleResourceDeleted('clusters')}
                   refreshMs={10000}
                   stateResourceDataKey="cluster"
                   resourceApiPath={`/teams/${team.metadata.name}/clusters/${cluster.metadata.name}`}
@@ -332,8 +322,8 @@ class TeamDashboard extends React.Component {
                 team={team.metadata.name}
                 namespaceClaim={namespaceClaim}
                 deleteNamespace={this.deleteNamespace}
-                handleUpdate={this.handleNamespaceUpdated}
-                handleDelete={this.handleNamespaceDeleted}
+                handleUpdate={this.handleResourceUpdated('namespaceClaims')}
+                handleDelete={this.handleResourceDeleted('namespaceClaims')}
                 refreshMs={15000}
                 stateResourceDataKey="namespaceClaim"
                 resourceApiPath={`/teams/${team.metadata.name}/namespaceclaims/${namespaceClaim.metadata.name}`}

--- a/pages/teams/[name].js
+++ b/pages/teams/[name].js
@@ -257,7 +257,15 @@ class TeamDashboard extends React.Component {
             renderItem={cluster => {
               const namespaceClaims = (this.state.namespaceClaims.items || []).filter(nc => nc.spec.cluster.name === cluster.metadata.name && !nc.deleted)
               return (
-                <Cluster team={team.metadata.name} cluster={cluster} namespaceClaims={namespaceClaims} handleDelete={this.handleClusterDeleted} />
+                <Cluster
+                  team={team.metadata.name}
+                  cluster={cluster}
+                  namespaceClaims={namespaceClaims}
+                  handleDelete={this.handleClusterDeleted}
+                  refreshMs={10000}
+                  stateResourceDataKey="cluster"
+                  resourceApiPath={`/teams/${team.metadata.name}/clusters/${cluster.metadata.name}`}
+                />
               )
             }}
           >
@@ -272,7 +280,14 @@ class TeamDashboard extends React.Component {
           <List
             dataSource={namespaceClaims.items}
             renderItem={namespaceClaim =>
-              <NamespaceClaim team={team.metadata.name} namespaceClaim={namespaceClaim} handleDelete={this.handleNamespaceDeleted} />
+              <NamespaceClaim
+                team={team.metadata.name}
+                namespaceClaim={namespaceClaim}
+                handleDelete={this.handleNamespaceDeleted}
+                refreshMs={1000}
+                stateResourceDataKey="namespaceClaim"
+                resourceApiPath={`/teams/${team.metadata.name}/namespaceclaims/${namespaceClaim.metadata.name}`}
+              />
             }
           >
           </List>


### PR DESCRIPTION
Moving state out of the `Cluster` and `NamespaceClaim` components, into the parent, team page, component.

Changes are made to these components through functions passed to them as props eg. update/delete. Once the state in the parent component is updated, the child components are refreshed with new props rendering the required changes.