### PR TITLE
Fix/enhancement for creating GKE creds in setup screens

### DIFF
--- a/lib/components/forms/GKECredentialsForm.js
+++ b/lib/components/forms/GKECredentialsForm.js
@@ -6,7 +6,9 @@ import GKECredentials from '../../crd/GKECredentials'
 import ResourceVerificationStatus from '../../components/ResourceVerificationStatus'
 import Allocation from '../../crd/Allocation'
 import apiRequest from '../../utils/api-request'
-import { Button, Form, Input, Alert, Select } from 'antd'
+import { Button, Form, Input, Alert, Select, message, Typography } from 'antd'
+
+const { Paragraph, Text } = Typography
 
 class GKECredentialsForm extends React.Component {
   static propTypes = {
@@ -14,7 +16,9 @@ class GKECredentialsForm extends React.Component {
     team: PropTypes.string.isRequired,
     allTeams: PropTypes.object,
     data: PropTypes.object,
-    handleSubmit: PropTypes.func.isRequired
+    handleSubmit: PropTypes.func.isRequired,
+    saveButtonText: PropTypes.string,
+    inlineVerification: PropTypes.bool
   }
 
   constructor(props) {
@@ -26,7 +30,8 @@ class GKECredentialsForm extends React.Component {
     this.state = {
       submitting: false,
       formErrorMessage: false,
-      allocations
+      allocations,
+      inlineVerificationFailed: false
     }
   }
 
@@ -46,6 +51,47 @@ class GKECredentialsForm extends React.Component {
     const state = copy(this.state)
     state.allocations = value
     this.setState(state)
+  }
+
+  async verify(gke, tryCount) {
+    const messageKey = 'verify'
+    tryCount = tryCount || 0
+    if (tryCount === 0) {
+      message.loading({ content: 'Verifying credentials', key: messageKey, duration: 0 })
+    }
+    if (tryCount === 3) {
+      message.error({ content: 'Credential verification failed', key: messageKey })
+      const state = copy(this.state)
+      state.inlineVerificationFailed = true
+      state.submitting = false
+      state.formErrorMessage = (
+        <div>
+          <Paragraph>The credentials have been saved but could not be verified, see the error below. Please try again or click &quot;Continue without verification&quot;.</Paragraph>
+          {(gke.status.conditions || []).map((c, idx) =>
+            <Paragraph key={idx} style={{ marginBottom: '0' }}>
+              <Text strong>{c.message}</Text>
+              <br/>
+              <Text>{c.detail}</Text>
+            </Paragraph>
+          )}
+        </div>
+      )
+      this.setState(state)
+    } else {
+      setTimeout(async () => {
+        const gkeResult = await apiRequest(null, 'get', `/teams/${this.props.team}/gkecredentials/${gke.metadata.name}`)
+        if (gkeResult.status.status === 'Success') {
+          message.success({ content: 'Credential verification successful', key: messageKey })
+          return await this.props.handleSubmit(gkeResult)
+        } else {
+          return await this.verify(gkeResult, tryCount + 1)
+        }
+      }, 2000)
+    }
+  }
+
+  continueWithoutVerification = async () => {
+    await this.props.handleSubmit()
   }
 
   handleSubmit = e => {
@@ -78,7 +124,13 @@ class GKECredentialsForm extends React.Component {
           }
           const allocationResult = await apiRequest(null, 'put', `/teams/${this.props.team}/allocations/${canonicalName}`, Allocation(canonicalName, allocationSpec))
           gkeResult.allocation = allocationResult
-          await this.props.handleSubmit(gkeResult)
+
+          if (this.props.inlineVerification) {
+            await this.verify(gkeResult)
+          } else {
+            await this.props.handleSubmit(gkeResult)
+          }
+
         } catch (err) {
           console.error('Error submitting form', err)
           const state = copy(this.state)
@@ -91,9 +143,9 @@ class GKECredentialsForm extends React.Component {
   }
 
   render() {
-    const { form, data, allTeams } = this.props
+    const { form, data, allTeams, saveButtonText } = this.props
     const { getFieldDecorator, getFieldsError, getFieldError, isFieldTouched } = form
-    const { formErrorMessage, allocations, submitting } = this.state
+    const { formErrorMessage, allocations, submitting, inlineVerificationFailed } = this.state
     const formConfig = {
       layout: 'horizontal',
       labelAlign: 'left',
@@ -147,7 +199,7 @@ class GKECredentialsForm extends React.Component {
           />
         ) : null}
 
-        {allocations ? (
+        {allTeams.items.length ? (
           <Form>
             <Form.Item label="Allocate team(s)" extra="If nothing selected then this integration will be available to ALL teams">
               {getFieldDecorator('allocations', { initialValue: allocations })(
@@ -164,7 +216,15 @@ class GKECredentialsForm extends React.Component {
               )}
             </Form.Item>
           </Form>
-        ) : null}
+        ) : (
+          <Alert
+            message="These credentials will be allocated to all teams"
+            description="No teams exist in Kore yet, therefore currently these credentials will be available to all teams created in the future. If you wish to restrict this please return here and allocate to teams once they have been created."
+            type="info"
+            showIcon
+            style={{ marginBottom: '20px', marginTop: '5px' }}
+          />
+        )}
 
         <Form {...formConfig} onSubmit={this.handleSubmit}>
           <FormErrorMessage />
@@ -209,7 +269,10 @@ class GKECredentialsForm extends React.Component {
             )}
           </Form.Item>
           <Form.Item style={{ marginBottom: '0'}}>
-            <Button type="primary" htmlType="submit" loading={submitting} disabled={this.disableButton(getFieldsError())}>Save</Button>
+            <Button type="primary" htmlType="submit" loading={submitting} disabled={this.disableButton(getFieldsError())}>{saveButtonText || 'Save'}</Button>
+            {inlineVerificationFailed ? (
+              <Button onClick={this.continueWithoutVerification} disabled={this.disableButton(getFieldsError())} style={{ marginLeft: '10px' }}>Continue without verification</Button>
+            ) : null}
           </Form.Item>
         </Form>
       </div>

--- a/pages/setup/kore/cloud-providers/index.js
+++ b/pages/setup/kore/cloud-providers/index.js
@@ -1,15 +1,19 @@
 import React from 'react'
+import PropTypes from 'prop-types'
 import { Typography, Card } from 'antd'
 const { Title, Paragraph } = Typography
 
 import redirect from '../../../../lib/utils/redirect'
 import copy from '../../../../lib/utils/object-copy'
+import apiRequest from '../../../../lib/utils/api-request'
 import { kore } from '../../../../config'
 import GKECredentialsForm from '../../../../lib/components/forms/GKECredentialsForm'
 import CloudSelector from '../../../../lib/components/cluster-build/CloudSelector'
 
 class ConfigureCloudProvidersPage extends React.Component {
-  static propTypes = {}
+  static propTypes = {
+    allTeams: PropTypes.object.isRequired
+  }
 
   static staticProps = {
     title: 'Configure cluster providers',
@@ -19,6 +23,12 @@ class ConfigureCloudProvidersPage extends React.Component {
 
   state = {
     selectedCloud: ''
+  }
+
+  static getInitialProps = async ctx => {
+    const allTeams = await apiRequest(ctx, 'get', '/teams')
+    allTeams.items = allTeams.items.filter(t => !kore.ignoreTeams.includes(t.metadata.name))
+    return { allTeams }
   }
 
   handleSelectCloud = cloud => {
@@ -35,6 +45,7 @@ class ConfigureCloudProvidersPage extends React.Component {
 
   render() {
     const { selectedCloud } = this.state
+    const { allTeams } = this.props
 
     return (
       <div>
@@ -45,7 +56,7 @@ class ConfigureCloudProvidersPage extends React.Component {
         </div>
         { selectedCloud === 'GKE' ? (
           <Card title="Enter GKE credentials" style={{ paddingBottom: '0' }}>
-            <GKECredentialsForm team={kore.koreAdminTeamName} handleSubmit={this.handleFormSubmit} />
+            <GKECredentialsForm team={kore.koreAdminTeamName} allTeams={allTeams} handleSubmit={this.handleFormSubmit} saveButtonText="Save & Verify" inlineVerification={true} />
           </Card>
         ) : null }
       </div>


### PR DESCRIPTION
* passing `allTeams` prop to the `GKECredentialsForm` component
* verify the credentials inline, if specified
* if not verified then set an error on the form and allow the user to save anyway
* don't show team allocation selector if there are no teams, instead show an info alert explaining the credentials would be available to all teams

**Inline verification during setup**
![gke-credential-verification-on-setup](https://user-images.githubusercontent.com/1334068/76782017-8e21ca80-67a7-11ea-9076-d566f615f3cf.gif)

**Showing error from verification failure**
<img width="1131" alt="Screen Shot 2020-03-17 at 14 27 20" src="https://user-images.githubusercontent.com/1334068/76866067-802d8180-685b-11ea-8483-1f1de225a45b.png">

Fixes #72 