### PR TITLE
Expired session client-side request error

### DIFF
--- a/server/middleware/ensure-authenticated.js
+++ b/server/middleware/ensure-authenticated.js
@@ -1,6 +1,11 @@
-module.exports = (req, res, next) => {
-  if (!req.isAuthenticated || !req.isAuthenticated()) {
-    return res.redirect('/login/refresh')
+module.exports = ({ redirect }) => {
+  return (req, res, next) => {
+    if (!req.isAuthenticated || !req.isAuthenticated()) {
+      if (redirect) {
+        return res.redirect('/login/refresh')
+      }
+      return res.status(401).send()
+    }
+    next()
   }
-  next()
 }

--- a/server/routes.js
+++ b/server/routes.js
@@ -24,12 +24,15 @@ openIdClient.init()
     console.error('Unexpected error occurred during openIdClient initialisation', err)
   })
 const ensureOpenIdClient = require('./middleware/ensure-openid-client')(openIdClient)
-router.use(require('./controllers/auth-local').initRouter({ authService, ensureAuthenticated, authCallback }))
+const ensureAuthenticatedRedirect = ensureAuthenticated({ redirect: true })
+const ensureAuthenticated401 = ensureAuthenticated({ redirect: false })
+
+router.use(require('./controllers/auth-local').initRouter({ authService, ensureAuthenticated: ensureAuthenticatedRedirect, authCallback }))
 router.use(require('./controllers/auth-openid').initRouter({ authService, ensureOpenIdClient, persistRequestedPath, embeddedAuth, authCallback }))
 
 // other routes must have an authenticated user
-router.use(require('./controllers/session').initRouter({ ensureAuthenticated, ensureUserCurrent, persistRequestedPath, orgService }))
-router.use(require('./controllers/apiproxy').initRouter({ ensureAuthenticated, ensureUserCurrent, koreApi }))
-router.use(require('./controllers/process').initRouter({ ensureAuthenticated, ensureUserCurrent, koreApi }))
+router.use(require('./controllers/session').initRouter({ ensureAuthenticated: ensureAuthenticated401, ensureUserCurrent, persistRequestedPath, orgService }))
+router.use(require('./controllers/apiproxy').initRouter({ ensureAuthenticated: ensureAuthenticatedRedirect, ensureUserCurrent, koreApi }))
+router.use(require('./controllers/process').initRouter({ ensureAuthenticated: ensureAuthenticatedRedirect, ensureUserCurrent, koreApi }))
 
 module.exports = router


### PR DESCRIPTION
* when the session is expired and the user makes a client-side request, the user session check was trying to return a redirect
* instead this should return a 401 and let the `_app.js` file handle the redirect
* fix by allowing the auth checking middleware to behave in two different ways - returning redirect or 401 which is configured as appropriate
* this is the UI session not the IDP session

Fixes #91 