### PR TITLE
Fixing auth refresh redirect

### DIFF
--- a/lib/utils/redirect.js
+++ b/lib/utils/redirect.js
@@ -7,7 +7,7 @@ const redirect = (res, path, forceSSR = false) => {
     return {}
   }
   if (forceSSR) {
-    window.location.pathname = path
+    window.location.href = path
   } else {
     Router.push(path)
   }


### PR DESCRIPTION
* used when the users IDP session has expired
* setting `href` instead of `pathname` to prevent escaping of URL