### PR TITLE
Show cluster access info in a modal

### DIFF
--- a/assets/antd-var-overrides.less
+++ b/assets/antd-var-overrides.less
@@ -1,4 +1,4 @@
-// override styles using less in here
+// override antd less vars here
 
 @hub-sider-color: #f0f2f5;
 

--- a/assets/styles.less
+++ b/assets/styles.less
@@ -1,0 +1,11 @@
+.copy-command {
+  font-family: monospace;
+  background-color: #f0f0f0;
+  padding: 10px;
+
+  .ant-typography-copy {
+    float: right;
+    font-size: 17px;
+    color: rgba(0, 0, 0, 0.65);
+  }
+}

--- a/next.config.js
+++ b/next.config.js
@@ -5,7 +5,7 @@ const path = require('path')
 
 // Where your antd-custom.less file lives
 const themeVariables = lessToJS(
-  fs.readFileSync(path.resolve(__dirname, './assets/antd-custom.less'), 'utf8')
+  fs.readFileSync(path.resolve(__dirname, './assets/antd-var-overrides.less'), 'utf8')
 )
 
 module.exports = withLess({

--- a/pages/_app.js
+++ b/pages/_app.js
@@ -15,6 +15,7 @@ import { kore, koreApi, server } from '../config'
 import OrgService from '../server/services/org'
 import userExpired from '../server/lib/user-expired'
 import gtag from '../lib/utils/gtag'
+import '../assets/styles.less'
 
 Router.events.on('routeChangeComplete', url => {
   gtag.pageView(url)

--- a/pages/teams/[name].js
+++ b/pages/teams/[name].js
@@ -3,7 +3,7 @@ import PropTypes from 'prop-types'
 import axios from 'axios'
 import Link from 'next/link'
 import Error from 'next/error'
-import { Typography, Card, List, Tag, Button, Avatar, Popconfirm, message, Select, Drawer, Badge, Alert } from 'antd'
+import { Typography, Card, List, Tag, Button, Avatar, Popconfirm, message, Select, Drawer, Badge, Alert, Icon, Modal } from 'antd'
 const { Paragraph, Text } = Typography
 const { Option } = Select
 
@@ -208,6 +208,22 @@ class TeamDashboard extends React.Component {
     }
   }
 
+  clusterAccess = () => {
+    Modal.info({
+      title: 'Cluster access',
+      content: (
+        <div style={{ marginTop: '20px' }}>
+          <Paragraph>You can use the Kore CLI to setup access to your team&apos;s clusters</Paragraph>
+          <Paragraph className="copy-command" style={{ marginRight: '40px' }} copyable>korectl clusters auth -t {this.props.team.metadata.name}</Paragraph>
+          <Paragraph>This will add local kubernetes configuration to allow you to use <Text style={{ fontFamily: 'monospace' }}>kubectl</Text> to talk to the provisioned cluster(s).</Paragraph>
+          <Paragraph>See examples: <a href="https://kubernetes.io/docs/reference/kubectl/overview/" target="_blank" rel="noopener noreferrer">https://kubernetes.io/docs/reference/kubectl/overview/</a></Paragraph>
+        </div>
+      ),
+      width: 700,
+      onOk() {}
+    })
+  }
+
   render() {
     const { team, user, invitation } = this.props
 
@@ -237,6 +253,7 @@ class TeamDashboard extends React.Component {
     }
 
     const membersAvailableToAdd = allUsers.filter(user => !members.items.includes(user))
+    const hasActiveClusters = Boolean(clusters.items.filter(c => c.status && c.status.status === 'Success').length)
 
     return (
       <div>
@@ -293,11 +310,17 @@ class TeamDashboard extends React.Component {
           title={<div><Text style={{ marginRight: '10px' }}>Clusters</Text><Badge style={{ backgroundColor: '#1890ff' }} count={clusters.items.filter(c => !c.deleted).length} /></div>}
           style={{ marginBottom: '20px' }}
           extra={
-            <Button type="primary">
-              <Link href="/teams/[name]/clusters/new" as={`/teams/${team.metadata.name}/clusters/new`}>
-                <a>+ New</a>
-              </Link>
-            </Button>
+            <div>
+              {hasActiveClusters ?
+                <Text style={{ marginRight: '20px' }}><a onClick={this.clusterAccess}><Icon type="eye" theme="twoTone" /> Access</a></Text> :
+                null
+              }
+              <Button type="primary">
+                <Link href="/teams/[name]/clusters/new" as={`/teams/${team.metadata.name}/clusters/new`}>
+                  <a>+ New</a>
+                </Link>
+              </Button>
+            </div>
           }
         >
           <List


### PR DESCRIPTION
* only show once there is at least one created cluster
* adding the ability to use custom CSS classes as specified in a LESS file
* amending name of LESS vars override file to make it clearer

<img width="1465" alt="Screen Shot 2020-03-23 at 15 29 50" src="https://user-images.githubusercontent.com/1334068/77333357-35a87b00-6d1b-11ea-97c1-21f6e138ff47.png">

Fixes https://github.com/appvia/kore/issues/341